### PR TITLE
Stable

### DIFF
--- a/gcm_defines.h
+++ b/gcm_defines.h
@@ -262,6 +262,16 @@ void
 aesni_gcm128_dec_finalize_avx_gen4(struct gcm_data *my_ctx_data,
                                    uint8_t *auth_tag, uint64_t auth_tag_len);
 
+void aesni_gcm128_precomp_sse(struct gcm_data *gdata);
+void aesni_gcm128_precomp_avx_gen2(struct gcm_data *gdata);
+void aesni_gcm128_precomp_avx_gen4(struct gcm_data *gdata);
+void aesni_gcm192_precomp_sse(struct gcm_data *gdata);
+void aesni_gcm192_precomp_avx_gen2(struct gcm_data *gdata);
+void aesni_gcm192_precomp_avx_gen4(struct gcm_data *gdata);
+void aesni_gcm256_precomp_sse(struct gcm_data *gdata);
+void aesni_gcm256_precomp_avx_gen2(struct gcm_data *gdata);
+void aesni_gcm256_precomp_avx_gen4(struct gcm_data *gdata);
+
 /**
  * @brief pre-processes GCM128 key data (SSE version)
  *
@@ -275,7 +285,6 @@ aesni_gcm128_dec_finalize_avx_gen4(struct gcm_data *my_ctx_data,
 __forceinline
 void aesni_gcm128_pre_sse(const void *key, struct gcm_data *gdata)
 {
-        extern void aesni_gcm128_precomp_sse(struct gcm_data *);
         //////
         // Prefill the key values for each round of encrypting/decrypting
         // Prefill the Sub Hash key values for encoding the tag
@@ -296,7 +305,6 @@ void aesni_gcm128_pre_sse(const void *key, struct gcm_data *gdata)
 __forceinline
 void aesni_gcm128_pre_avx_gen2(const void *key, struct gcm_data *gdata)
 {
-        extern void aesni_gcm128_precomp_avx_gen2(struct gcm_data *);
         //////
         // Prefill the key values for each round of encrypting/decrypting
         // Prefill the Sub Hash key values for encoding the tag
@@ -317,7 +325,6 @@ void aesni_gcm128_pre_avx_gen2(const void *key, struct gcm_data *gdata)
 __forceinline
 void aesni_gcm128_pre_avx_gen4(const void *key, struct gcm_data *gdata)
 {
-        extern void aesni_gcm128_precomp_avx_gen4(struct gcm_data *);
         //////
         // Prefill the key values for each round of encrypting/decrypting
         // Prefill the Sub Hash key values for encoding the tag
@@ -339,7 +346,6 @@ void aesni_gcm128_pre_avx_gen4(const void *key, struct gcm_data *gdata)
 __forceinline
 void aesni_gcm192_pre_sse(const void *key, struct gcm_data *gdata)
 {
-        extern void aesni_gcm192_precomp_sse(struct gcm_data *);
         //////
         // Prefill the key values for each round of encrypting/decrypting
         // Prefill the Sub Hash key values for encoding the tag
@@ -360,7 +366,6 @@ void aesni_gcm192_pre_sse(const void *key, struct gcm_data *gdata)
 __forceinline
 void aesni_gcm192_pre_avx_gen2(const void *key, struct gcm_data *gdata)
 {
-        extern void aesni_gcm192_precomp_avx_gen2(struct gcm_data *);
         //////
         // Prefill the key values for each round of encrypting/decrypting
         // Prefill the Sub Hash key values for encoding the tag
@@ -381,7 +386,6 @@ void aesni_gcm192_pre_avx_gen2(const void *key, struct gcm_data *gdata)
 __forceinline
 void aesni_gcm192_pre_avx_gen4(const void *key, struct gcm_data *gdata)
 {
-        extern void aesni_gcm192_precomp_avx_gen4(struct gcm_data *);
         //////
         // Prefill the key values for each round of encrypting/decrypting
         // Prefill the Sub Hash key values for encoding the tag
@@ -729,7 +733,6 @@ __forceinline
 void aesni_gcm256_pre_sse(const void *key, struct gcm_data *gdata)
 {
         struct gcm_data tmp;
-        void aesni_gcm256_precomp_sse(struct gcm_data *);
         //////
         // Prefill the key values for each round of encrypting/decrypting
         // Prefill the Sub Hash key values for encoding the tag
@@ -747,7 +750,6 @@ void aesni_gcm256_pre_sse(const void *key, struct gcm_data *gdata)
 __forceinline
 void aesni_gcm256_pre_avx_gen2(const void *key, struct gcm_data *gdata)
 {
-        extern void aesni_gcm256_precomp_avx_gen2(struct gcm_data *);
         //////
         // Prefill the key values for each round of encrypting/decrypting
         // Prefill the Sub Hash key values for encoding the tag
@@ -765,7 +767,6 @@ void aesni_gcm256_pre_avx_gen2(const void *key, struct gcm_data *gdata)
 __forceinline
 void aesni_gcm256_pre_avx_gen4(const void *key, struct gcm_data *gdata)
 {
-        extern void aesni_gcm256_precomp_avx_gen4(struct gcm_data *);
         //////
         // Prefill the key values for each round of encrypting/decrypting
         // Prefill the Sub Hash key values for encoding the tag


### PR DESCRIPTION
Hi Tomasz, thank you for merging my request.
This patch is intended to make NULL_CIPHER easier to use.
NULL＿CIPHER is very useful in product development.
why not recommended to use NULL_CIPHER and NULL_HASH?

In addition, I have some suggestions.
(1) separate the expanded_keys from gcm_data.
(2) integrate GCM API into MB.

I like this library because it is very fast.


