### PR TITLE
Fix dependency with obj directory for Windows x64

### DIFF
--- a/win_x64.mak
+++ b/win_x64.mak
@@ -188,6 +188,8 @@ all: $(LIBNAME)
 $(LIBNAME): $(all_objs)
 	$(LIB_TOOL) $(LIBFLAGS) /out:$@ $(all_objs)
 
+$(all_objs): $(OBJ_DIR)
+
 {.\}.c{$(OBJ_DIR)}.obj:
 	$(CC) /Fo$@ /c $(CFLAGS) $<
 


### PR DESCRIPTION
On the first run of nmake from a fresh clone:
nasm: fatal: unable to open output file `obj\aes128_cbc_dec_by4_sse.obj'

The obj directory must be done at first.

Fixes: 3d62708a90cb ("Windows x64 compilation option added...")
Signed-off-by: Jean-Mickael Guerin <jean-mickael.guerin@6wind.com>