### PR TITLE
Fix issue with parallel use of a gcm_ctx

### DIFF
--- a/LibTestApp/gcm_test.c
+++ b/LibTestApp/gcm_test.c
@@ -730,6 +730,7 @@ static const struct gcm_ctr_vector gcm_vectors[] = {
 
 
 typedef void (*gcm_enc_dec_fn_t)(struct gcm_data *,
+                                 struct gcm_data_comp *,
                                  uint8_t *, uint8_t const *, uint64_t,
                                  uint8_t *, uint8_t const *, uint64_t,
                                  uint8_t *, uint64_t);
@@ -773,6 +774,7 @@ static int check_data(uint8_t * test, uint8_t * expected, uint64_t len,
 static int test_gcm128_std_vectors(struct gcm_ctr_vector const *vector)
 {
 	struct gcm_data gdata;
+	struct gcm_data_comp ldata;
 	int is_error = 0;
 	// Temporary array for the calculated vectors
 	uint8_t *ct_test = NULL;
@@ -818,7 +820,7 @@ static int test_gcm128_std_vectors(struct gcm_ctr_vector const *vector)
 	////
 	// Encrypt
 	////
-	aesni_gcm128_enc(&gdata, ct_test, vector->P, vector->Plen,
+	aesni_gcm128_enc(&gdata, &ldata, ct_test, vector->P, vector->Plen,
 			 IV_c, vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(ct_test, vector->C, vector->Plen,
                                "encrypted cypher text (C)");
@@ -826,7 +828,7 @@ static int test_gcm128_std_vectors(struct gcm_ctr_vector const *vector)
 
 	// test of in-place encrypt
 	memcpy(pt_test, vector->P, vector->Plen);
-	aesni_gcm128_enc(&gdata, pt_test, pt_test, vector->Plen, IV_c,
+	aesni_gcm128_enc(&gdata, &ldata, pt_test, pt_test, vector->Plen, IV_c,
 			 vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(pt_test, vector->C, vector->Plen,
                                "encrypted cypher text(in-place)");
@@ -836,7 +838,7 @@ static int test_gcm128_std_vectors(struct gcm_ctr_vector const *vector)
 	////
 	// Decrypt
 	////
-	aesni_gcm128_dec(&gdata, pt_test, vector->C, vector->Plen,
+	aesni_gcm128_dec(&gdata, &ldata, pt_test, vector->C, vector->Plen,
 			 IV_c, vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(pt_test, vector->P, vector->Plen,
                                "decrypted plain text (P)");
@@ -847,17 +849,17 @@ static int test_gcm128_std_vectors(struct gcm_ctr_vector const *vector)
 
 	// test in in-place decrypt
 	memcpy(ct_test, vector->C, vector->Plen);
-	aesni_gcm128_dec(&gdata, ct_test, ct_test, vector->Plen, IV_c,
+	aesni_gcm128_dec(&gdata, &ldata, ct_test, ct_test, vector->Plen, IV_c,
 			 vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(ct_test, vector->P, vector->Plen,
                                "plain text (P) - in-place");
 	is_error |= check_data(T_test, vector->T, vector->Tlen,
                                "decrypted tag (T) - in-place");
 	// enc -> dec
-	aesni_gcm128_enc(&gdata, ct_test, vector->P, vector->Plen,
+	aesni_gcm128_enc(&gdata, &ldata, ct_test, vector->P, vector->Plen,
 			 IV_c, vector->A, vector->Alen, T_test, vector->Tlen);
 	memset(pt_test, 0, vector->Plen);
-	aesni_gcm128_dec(&gdata, pt_test, ct_test, vector->Plen, IV_c,
+	aesni_gcm128_dec(&gdata, &ldata, pt_test, ct_test, vector->Plen, IV_c,
 			 vector->A, vector->Alen, T2_test, vector->Tlen);
 	is_error |= check_data(pt_test, vector->P, vector->Plen,
                                "self decrypted plain text (P)");
@@ -883,6 +885,7 @@ static int test_gcm128_std_vectors(struct gcm_ctr_vector const *vector)
 static int test_gcm192_std_vectors(struct gcm_ctr_vector const *vector)
 {
 	struct gcm_data gdata;
+	struct gcm_data_comp ldata;
 	int is_error = 0;
 	// Temporary array for the calculated vectors
 	uint8_t *ct_test = NULL;
@@ -925,7 +928,7 @@ static int test_gcm192_std_vectors(struct gcm_ctr_vector const *vector)
 	// Encrypt
 	////
 	memset(ct_test, 0, vector->Plen);
-	aesni_gcm192_enc(&gdata, ct_test, vector->P, vector->Plen,
+	aesni_gcm192_enc(&gdata, &ldata, ct_test, vector->P, vector->Plen,
 			 IV_c, vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(ct_test, vector->C, vector->Plen,
                                "encrypted cypher text (C)");
@@ -933,7 +936,7 @@ static int test_gcm192_std_vectors(struct gcm_ctr_vector const *vector)
 
 	// test of in-place encrypt
 	memcpy(pt_test, vector->P, vector->Plen);
-	aesni_gcm192_enc(&gdata, pt_test, pt_test, vector->Plen, IV_c,
+	aesni_gcm192_enc(&gdata, &ldata, pt_test, pt_test, vector->Plen, IV_c,
 			 vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(pt_test, vector->C, vector->Plen,
                                "encrypted cypher text(in-place)");
@@ -943,7 +946,7 @@ static int test_gcm192_std_vectors(struct gcm_ctr_vector const *vector)
 	////
 	// Decrypt
 	////
-	aesni_gcm192_dec(&gdata, pt_test, vector->C, vector->Plen,
+	aesni_gcm192_dec(&gdata, &ldata, pt_test, vector->C, vector->Plen,
 			 IV_c, vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(pt_test, vector->P, vector->Plen,
                                "decrypted plain text (P)");
@@ -954,17 +957,17 @@ static int test_gcm192_std_vectors(struct gcm_ctr_vector const *vector)
 
 	// test in in-place decrypt
 	memcpy(ct_test, vector->C, vector->Plen);
-	aesni_gcm192_dec(&gdata, ct_test, ct_test, vector->Plen, IV_c,
+	aesni_gcm192_dec(&gdata, &ldata, ct_test, ct_test, vector->Plen, IV_c,
 			 vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(ct_test, vector->P, vector->Plen,
                                "plain text (P) - in-place");
 	is_error |= check_data(T_test, vector->T, vector->Tlen,
                                "decrypted tag (T) - in-place");
 	// enc -> dec
-	aesni_gcm192_enc(&gdata, ct_test, vector->P, vector->Plen,
+	aesni_gcm192_enc(&gdata, &ldata, ct_test, vector->P, vector->Plen,
 			 IV_c, vector->A, vector->Alen, T_test, vector->Tlen);
 	memset(pt_test, 0, vector->Plen);
-	aesni_gcm192_dec(&gdata, pt_test, ct_test, vector->Plen, IV_c,
+	aesni_gcm192_dec(&gdata, &ldata, pt_test, ct_test, vector->Plen, IV_c,
 			 vector->A, vector->Alen, T2_test, vector->Tlen);
 	is_error |= check_data(pt_test, vector->P, vector->Plen,
                                "self decrypted plain text (P)");
@@ -988,6 +991,7 @@ static int test_gcm192_std_vectors(struct gcm_ctr_vector const *vector)
 static int test_gcm256_std_vectors(struct gcm_ctr_vector const *vector)
 {
 	struct gcm_data gdata;
+	struct gcm_data_comp ldata;
 	int is_error = 0;
 	// Temporary array for the calculated vectors
 	uint8_t *ct_test = NULL;
@@ -1030,7 +1034,7 @@ static int test_gcm256_std_vectors(struct gcm_ctr_vector const *vector)
 	// Encrypt
 	////
 	memset(ct_test, 0, vector->Plen);
-	aesni_gcm256_enc(&gdata, ct_test, vector->P, vector->Plen,
+	aesni_gcm256_enc(&gdata, &ldata, ct_test, vector->P, vector->Plen,
 			 IV_c, vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(ct_test, vector->C, vector->Plen,
                                "encrypted cypher text (C)");
@@ -1038,7 +1042,7 @@ static int test_gcm256_std_vectors(struct gcm_ctr_vector const *vector)
 
 	// test of in-place encrypt
 	memcpy(pt_test, vector->P, vector->Plen);
-	aesni_gcm256_enc(&gdata, pt_test, pt_test, vector->Plen, IV_c,
+	aesni_gcm256_enc(&gdata, &ldata, pt_test, pt_test, vector->Plen, IV_c,
 			 vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(pt_test, vector->C, vector->Plen,
                                "encrypted cypher text(in-place)");
@@ -1048,7 +1052,7 @@ static int test_gcm256_std_vectors(struct gcm_ctr_vector const *vector)
 	////
 	// Decrypt
 	////
-	aesni_gcm256_dec(&gdata, pt_test, vector->C, vector->Plen,
+	aesni_gcm256_dec(&gdata, &ldata, pt_test, vector->C, vector->Plen,
 			 IV_c, vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(pt_test, vector->P, vector->Plen,
                                "decrypted plain text (P)");
@@ -1059,17 +1063,17 @@ static int test_gcm256_std_vectors(struct gcm_ctr_vector const *vector)
 
 	// test in in-place decrypt
 	memcpy(ct_test, vector->C, vector->Plen);
-	aesni_gcm256_dec(&gdata, ct_test, ct_test, vector->Plen, IV_c,
+	aesni_gcm256_dec(&gdata, &ldata, ct_test, ct_test, vector->Plen, IV_c,
 			 vector->A, vector->Alen, T_test, vector->Tlen);
 	is_error |= check_data(ct_test, vector->P, vector->Plen,
                                "plain text (P) - in-place");
 	is_error |= check_data(T_test, vector->T, vector->Tlen,
                                "decrypted tag (T) - in-place");
 	// enc -> dec
-	aesni_gcm256_enc(&gdata, ct_test, vector->P, vector->Plen,
+	aesni_gcm256_enc(&gdata, &ldata, ct_test, vector->P, vector->Plen,
 			 IV_c, vector->A, vector->Alen, T_test, vector->Tlen);
 	memset(pt_test, 0, vector->Plen);
-	aesni_gcm256_dec(&gdata, pt_test, ct_test, vector->Plen, IV_c,
+	aesni_gcm256_dec(&gdata, &ldata, pt_test, ct_test, vector->Plen, IV_c,
 			 vector->A, vector->Alen, T2_test, vector->Tlen);
 	is_error |=
                 check_data(pt_test, vector->P, vector->Plen,

--- a/avx/gcm128_avx_gen2.asm
+++ b/avx/gcm128_avx_gen2.asm
@@ -376,20 +376,22 @@ default rel
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; PARTIAL_BLOCK: Handles encryption/decryption and the tag partial blocks between update calls.
 ; Requires the input data be at least 1 byte long.
-; Input: gcm_data struct* (GDATA), input text (PLAIN_CYPH_IN), input text length (PLAIN_CYPH_LEN),
-; the current data offset (DATA_OFFSET), and whether encoding or decoding (ENC_DEC)
-; Output: A cypher of the first partial block (CYPH_PLAIN_OUT), and updated GDATA
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), input text (PLAIN_CYPH_IN),
+; input text length (PLAIN_CYPH_LEN), the current data offset (DATA_OFFSET), and whether
+; encoding or decoding (ENC_DEC)
+; Output: A cypher of the first partial block (CYPH_PLAIN_OUT), and updated GDATA_C
 ; Clobbers rax, r10, r12, r13, r15, xmm0, xmm1, xmm2, xmm3, xmm5, xmm6, xmm9, xmm10, xmm11, xmm13
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro PARTIAL_BLOCK	7
+%macro PARTIAL_BLOCK	8
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%PLAIN_CYPH_LEN	%4
-%define	%%DATA_OFFSET		%5
-%define	%%AAD_HASH		%6
-%define	%%ENC_DEC		%7
-	mov	r13, [%%GDATA + PBlockLen]
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%PLAIN_CYPH_LEN	%5
+%define	%%DATA_OFFSET		%6
+%define	%%AAD_HASH		%7
+%define	%%ENC_DEC		%8
+	mov	r13, [%%GDATA_C + PBlockLen]
 	cmp	r13, 0
 	je	%%_partial_block_done		;Leave Macro if no partial blocks
 
@@ -405,7 +407,7 @@ default rel
 %%_data_read:				;Finished reading in data
 
 
-	vmovdqu	xmm9, [%%GDATA + PBlockEncKey]	;xmm9 = my_ctx_data.partial_block_enc_key
+	vmovdqu	xmm9, [%%GDATA_C + PBlockEncKey]	;xmm9 = my_comp_data.partial_block_enc_key
 	vmovdqu	xmm13, [%%GDATA + HashKey]
 
 	lea	r12, [SHIFT_MASK]
@@ -440,12 +442,12 @@ default rel
 
 	GHASH_MUL	%%AAD_HASH, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6	;GHASH computation for the last <16 Byte block
 	xor	rax,rax
-	mov	[%%GDATA+PBlockLen], rax
+	mov	[%%GDATA_C + PBlockLen], rax
 	jmp	%%_dec_done
 %%_partial_incomplete_1:
-	add	[%%GDATA+PBlockLen], %%PLAIN_CYPH_LEN
+	add	[%%GDATA_C + PBlockLen], %%PLAIN_CYPH_LEN
 %%_dec_done:
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH
 
 %else
 	vpxor	xmm9, xmm1	; Plaintext XOR E(K, Yn)
@@ -469,12 +471,12 @@ default rel
 
 	GHASH_MUL	%%AAD_HASH, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6	;GHASH computation for the last <16 Byte block
 	xor	rax,rax
-	mov	[%%GDATA+PBlockLen], rax
+	mov	[%%GDATA_C + PBlockLen], rax
 	jmp	%%_encode_done
 %%_partial_incomplete_2:
-	add [%%GDATA+PBlockLen], %%PLAIN_CYPH_LEN
+	add [%%GDATA_C + PBlockLen], %%PLAIN_CYPH_LEN
 %%_encode_done:
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH
 
 	vpshufb	xmm9, [SHUF_MASK]	; shuffle xmm9 back to output as ciphertext
 	vpshufb	xmm9, xmm2
@@ -519,35 +521,36 @@ default rel
 ; %%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r14 are used as a pointer only, not modified.
 ; Updated AAD_HASH is returned in %%T3
 
-%macro INITIAL_BLOCKS 23
+%macro INITIAL_BLOCKS 24
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%LENGTH		%4
-%define	%%DATA_OFFSET		%5
-%define	%%num_initial_blocks	%6      ; can be 0, 1, 2, 3, 4, 5, 6 or 7
-%define	%%T1		%7
-%define	%%HASH_KEY	%8
-%define	%%T3		%9
-%define	%%T4		%10
-%define	%%T5		%11
-%define	%%CTR		%12
-%define	%%XMM1		%13
-%define	%%XMM2		%14
-%define	%%XMM3		%15
-%define	%%XMM4		%16
-%define	%%XMM5		%17
-%define	%%XMM6		%18
-%define	%%XMM7		%19
-%define	%%XMM8		%20
-%define	%%T6		%21
-%define	%%T_key		%22
-%define	%%ENC_DEC	%23
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%LENGTH		%5
+%define	%%DATA_OFFSET		%6
+%define	%%num_initial_blocks	%7      ; can be 0, 1, 2, 3, 4, 5, 6 or 7
+%define	%%T1		%8
+%define	%%HASH_KEY	%9
+%define	%%T3		%10
+%define	%%T4		%11
+%define	%%T5		%12
+%define	%%CTR		%13
+%define	%%XMM1		%14
+%define	%%XMM2		%15
+%define	%%XMM3		%16
+%define	%%XMM4		%17
+%define	%%XMM5		%18
+%define	%%XMM6		%19
+%define	%%XMM7		%20
+%define	%%XMM8		%21
+%define	%%T6		%22
+%define	%%T_key		%23
+%define	%%ENC_DEC	%24
 
 %assign i (8-%%num_initial_blocks)
 		vmovdqu	reg(i), %%XMM8	; move AAD_HASH to temp reg
 	        ; start AES for %%num_initial_blocks blocks
-	        vmovdqu  %%CTR, [%%GDATA + CurCount]                   ; %%CTR = Y0
+	        vmovdqu  %%CTR, [%%GDATA_C + CurCount]                   ; %%CTR = Y0
 
 
 %assign i (9-%%num_initial_blocks)
@@ -1395,16 +1398,17 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; GCM_INIT initializes a gcm_data struct to prepare for encoding/decoding.
-; Input: gcm_data struct* (GDATA), IV, Additional Authentication data (A_IN), Additional
-; Data length (A_LEN)
-; Output: Updated GDATA with the hash of A_IN (AadHash) and initialized other parts of GDATA.
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), IV, Additional
+; Authentication data (A_IN), Additional Data length (A_LEN)
+; Output: Updated GDATA_C with the hash of A_IN (AadHash) and initialized other parts of GDATA_C.
 ; Clobbers rax, r10-r13, and xmm0-xmm6
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_INIT 	4
+%macro	GCM_INIT 	5
 %define	%%GDATA		%1
-%define	%%IV		%2
-%define	%%A_IN		%3
-%define	%%A_LEN		%4
+%define	%%GDATA_C	%2
+%define	%%IV		%3
+%define	%%A_IN		%4
+%define	%%A_LEN		%5
 %define	%%AAD_HASH	xmm0
 %define	%%SUBHASH	xmm1
 
@@ -1415,19 +1419,19 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 	vpxor	xmm2, xmm3
 	mov	r10, %%A_LEN
 
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH		; my_ctx_data.aad hash = aad_hash
-	mov	[%%GDATA + AadLen], r10			; my_ctx_data.aad_length = aad_length
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH	; my_comp_data.aad hash = aad_hash
+	mov	[%%GDATA_C + AadLen], r10		; my_comp_data.aad_length = aad_length
 	xor	r10, r10
-	mov	[%%GDATA + InLen], r10			; my_ctx_data.in_length = 0
-	mov	[%%GDATA + PBlockLen], r10		; my_ctx_data.partial_block_length = 0
-	vmovdqu	[%%GDATA + PBlockEncKey], xmm2		; my_ctx_data.partial_block_enc_key = 0
+	mov	[%%GDATA_C + InLen], r10		; my_comp_data.in_length = 0
+	mov	[%%GDATA_C + PBlockLen], r10		; my_comp_data.partial_block_length = 0
+	vmovdqu	[%%GDATA_C + PBlockEncKey], xmm2	; my_comp_data.partial_block_enc_key = 0
 	mov	r10, %%IV
 	vmovdqu	xmm2, [r10]
-	vmovdqu	[%%GDATA + OrigIV], xmm2		; my_ctx_data.orig_IV = iv
+	vmovdqu	[%%GDATA_C + OrigIV], xmm2		; my_comp_data.orig_IV = iv
 
 	vpshufb xmm2, [SHUF_MASK]
 
-	vmovdqu	[%%GDATA + CurCount], xmm2		; my_ctx_data.current_counter = iv
+	vmovdqu	[%%GDATA_C + CurCount], xmm2		; my_comp_data.current_counter = iv
 %endmacro
 
 
@@ -1435,17 +1439,18 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 ; GCM_ENC_DEC Encodes/Decodes given data. Assumes that the passed gcm_data struct has been
 ; initialized by GCM_INIT
 ; Requires the input data be at least 1 byte long because of READ_SMALL_INPUT_DATA.
-; Input: gcm_data struct* (GDATA), input text (PLAIN_CYPH_IN), input text length (PLAIN_CYPH_LEN),
-; and whether encoding or decoding (ENC_DEC)
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), input text (PLAIN_CYPH_IN),
+; input text length (PLAIN_CYPH_LEN), and whether encoding or decoding (ENC_DEC)
 ; Output: A cypher of the given plain text (CYPH_PLAIN_OUT), and updated GDATA
 ; Clobbers rax, r10-r15, and xmm0-xmm15
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_ENC_DEC 		5
+%macro	GCM_ENC_DEC 		6
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%PLAIN_CYPH_LEN	%4
-%define	%%ENC_DEC		%5
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%PLAIN_CYPH_LEN	%5
+%define	%%ENC_DEC		%6
 %define	%%DATA_OFFSET		r11
 
 ; Macro flow:
@@ -1457,12 +1462,12 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 	je	%%_multiple_of_16_bytes
 
 	xor %%DATA_OFFSET, %%DATA_OFFSET
-	add [%%GDATA+InLen], %%PLAIN_CYPH_LEN ;Update length of data processed
+	add [%%GDATA_C + InLen], %%PLAIN_CYPH_LEN ;Update length of data processed
 	vmovdqu  xmm13, [%%GDATA + HashKey]                 ; xmm13 = HashKey
-	vmovdqu xmm8, [%%GDATA + AadHash]
+	vmovdqu xmm8, [%%GDATA_C + AadHash]
 
 
-	PARTIAL_BLOCK %%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, %%PLAIN_CYPH_LEN, %%DATA_OFFSET, xmm8, %%ENC_DEC
+	PARTIAL_BLOCK %%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, %%PLAIN_CYPH_LEN, %%DATA_OFFSET, xmm8, %%ENC_DEC
 
 
 	mov	r13, %%PLAIN_CYPH_LEN
@@ -1492,42 +1497,42 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
         jmp     %%_initial_num_blocks_is_1
 
 %%_initial_num_blocks_is_7:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 7, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 7, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*7
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_6:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 6, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 6, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*6
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_5:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 5, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 5, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*5
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_4:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 4, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 4, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*4
         jmp     %%_initial_blocks_encrypted
 
 
 %%_initial_num_blocks_is_3:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 3, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 3, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*3
         jmp     %%_initial_blocks_encrypted
 %%_initial_num_blocks_is_2:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 2, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 2, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*2
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_1:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 1, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 1, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_0:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 0, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 0, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
 
 
 %%_initial_blocks_encrypted:
@@ -1579,22 +1584,22 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 
 
 %%_zero_cipher_left:
-	vmovdqu	[%%GDATA + AadHash], xmm14		; my_ctx_data.aad hash = xmm14
-	vmovdqu	[%%GDATA + CurCount], xmm9		; my_ctx_data.current_counter = xmm9
+	vmovdqu	[%%GDATA_C + AadHash], xmm14		; my_comp_data.aad hash = xmm14
+	vmovdqu	[%%GDATA_C + CurCount], xmm9		; my_comp_data.current_counter = xmm9
 
         mov     r13, r10
         and     r13, 15                                 ; r13 = (%%PLAIN_CYPH_LEN mod 16)
 
         je      %%_multiple_of_16_bytes
 
-	mov	[%%GDATA + PBlockLen], r13		; my_ctx_data.partial_blck_length = r13
+	mov	[%%GDATA_C + PBlockLen], r13		; my_comp_data.partial_blck_length = r13
         ; handle the last <16 Byte block seperately
 
         vpaddd   xmm9, [ONE]                     ; INCR CNT to get Yn
-        vmovdqu [%%GDATA + CurCount], xmm9              ; my_ctx_data.current_counter = xmm9
+        vmovdqu [%%GDATA_C + CurCount], xmm9		; my_comp_data.current_counter = xmm9
         vpshufb  xmm9, [SHUF_MASK]
         ENCRYPT_SINGLE_BLOCK   %%GDATA, xmm9             ; E(K, Yn)
-	vmovdqu	[%%GDATA + PBlockEncKey], xmm9		; my_ctx_data.partial_block_enc_key = xmm9
+	vmovdqu	[%%GDATA_C + PBlockEncKey], xmm9	; my_comp_data.partial_block_enc_key = xmm9
 
 	cmp	%%PLAIN_CYPH_LEN, 16
 	jge	%%_large_enough_update
@@ -1629,7 +1634,7 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
         vpand    xmm2, xmm1
         vpshufb  xmm2, [SHUF_MASK]
         vpxor    xmm14, xmm2
-	 vmovdqu	[%%GDATA + AadHash], xmm14
+	 vmovdqu	[%%GDATA_C + AadHash], xmm14
 
         %else
         vpxor    xmm9, xmm1                              ; Plaintext XOR E(K, Yn)
@@ -1637,7 +1642,7 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
         vpand    xmm9, xmm1                              ; mask out top 16-r13 bytes of xmm9
         vpshufb  xmm9, [SHUF_MASK]
         vpxor    xmm14, xmm9
-	vmovdqu	[%%GDATA + AadHash], xmm14
+	vmovdqu	[%%GDATA_C + AadHash], xmm14
 
         vpshufb  xmm9, [SHUF_MASK]               ; shuffle xmm9 back to output as ciphertext
         %endif
@@ -1671,19 +1676,21 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; GCM_COMPLETE Finishes Encyrption/Decryption of last partial block after GCM_UPDATE finishes.
-; Input: A gcm_data struct* (GDATA) and  whether encoding or decoding (ENC_DEC).
+; Input: A gcm_data struct* (GDATA) with a gcm_data_comp struct* (GDATA_C) and  whether
+; encoding or decoding (ENC_DEC).
 ; Output: Authorization Tag (AUTH_TAG) and Authorization Tag length (AUTH_TAG_LEN)
 ; Clobbers rax, r10-r12, and xmm0, xmm1, xmm5, xmm6, xmm9, xmm11, xmm14, xmm15
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_COMPLETE		4
+%macro	GCM_COMPLETE		5
 %define	%%GDATA			%1
-%define	%%AUTH_TAG		%2
-%define	%%AUTH_TAG_LEN		%3
-%define	%%ENC_DEC		%4
+%define	%%GDATA_C		%2
+%define	%%AUTH_TAG		%3
+%define	%%AUTH_TAG_LEN		%4
+%define	%%ENC_DEC		%5
 %define	%%PLAIN_CYPH_LEN	rax
 
-	mov	r12, [%%GDATA + PBlockLen]
-	vmovdqu	xmm14, [%%GDATA+AadHash]
+	mov	r12, [%%GDATA_C + PBlockLen]
+	vmovdqu	xmm14, [%%GDATA_C + AadHash]
 	vmovdqu xmm13, [%%GDATA+HashKey]
 
 	cmp	r12, 0
@@ -1691,12 +1698,12 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 	je %%_partial_done
 
 	GHASH_MUL xmm14, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6 ;GHASH computation for the last <16 Byte block
-	vmovdqu [%%GDATA+AadHash], xmm14
+	vmovdqu [%%GDATA_C + AadHash], xmm14
 
 %%_partial_done:
 
-        mov     r12, [%%GDATA + AadLen]			; r12 = aadLen (number of bytes)
-	mov	%%PLAIN_CYPH_LEN, [%%GDATA+InLen]
+        mov     r12, [%%GDATA_C + AadLen]		; r12 = aadLen (number of bytes)
+	mov	%%PLAIN_CYPH_LEN, [%%GDATA_C + InLen]
 
         shl     r12, 3                                  ; convert into number of bits
         vmovd    xmm15, r12d                             ; len(A) in xmm15
@@ -1710,7 +1717,7 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
         GHASH_MUL       xmm14, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6    ; final GHASH computation
         vpshufb  xmm14, [SHUF_MASK]              ; perform a 16Byte swap
 
-        vmovdqu  xmm9, [%%GDATA+OrigIV]                            ; xmm9 = Y0
+        vmovdqu  xmm9, [%%GDATA_C + OrigIV]                            ; xmm9 = Y0
 
         ENCRYPT_SINGLE_BLOCK %%GDATA, xmm9                    ; E(K, Y0)
 
@@ -1806,6 +1813,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_init_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *iv, /* Pre-counter block j0: 4 byte salt (from Security Association) concatenated with 8 byte Initialisation Vector (from IPSec ESP Payload) concatenated with 0x00000001. 16-byte pointer. */
 ;        const   u8 *aad, /* Additional Authentication Data (AAD)*/
 ;        u64     aad_len); /* Length of AAD in bytes (must be a multiple of 4 bytes). */
@@ -1822,7 +1830,7 @@ aesni_gcm128_init_avx_gen2:
 	vmovdqu	[rsp + 0*16],xmm6
 %endif
 
-	GCM_INIT arg1, arg2, arg3, arg4
+	GCM_INIT arg1, arg2, arg3, arg4, arg5
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm6 , [rsp + 0*16]
@@ -1836,6 +1844,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_enc_update_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Ciphertext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Plaintext input */
 ;        u64     plaintext_len); /* Length of data in Bytes for encryption. must be a multiple of 16 bytes*/
@@ -1845,7 +1854,7 @@ aesni_gcm128_enc_update_avx_gen2:
 
 	FUNC_SAVE
 
-	GCM_ENC_DEC arg1, arg2, arg3, arg4, ENC
+	GCM_ENC_DEC arg1, arg2, arg3, arg4, arg5, ENC
 
 	FUNC_RESTORE
 
@@ -1855,6 +1864,7 @@ aesni_gcm128_enc_update_avx_gen2:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_dec_update_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Plaintext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Cyphertext input */
 ;        u64     plaintext_len); /* Length of data in Bytes for encryption. must be a multiple of 16 bytes*/
@@ -1864,7 +1874,7 @@ aesni_gcm128_dec_update_avx_gen2:
 
 	FUNC_SAVE
 
-	GCM_ENC_DEC arg1, arg2, arg3, arg4, DEC
+	GCM_ENC_DEC arg1, arg2, arg3, arg4, arg5, DEC
 
 	FUNC_RESTORE
 
@@ -1874,6 +1884,7 @@ aesni_gcm128_dec_update_avx_gen2:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_enc_finalize_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *auth_tag, /* Authenticated Tag output. */
 ;        u64     auth_tag_len); /* Authenticated Tag Length in bytes. Valid values are 16 (most likely), 12 or 8. */
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1891,7 +1902,7 @@ aesni_gcm128_enc_finalize_avx_gen2:
 	vmovdqu	[rsp + 3*16],xmm14
 	vmovdqu	[rsp + 4*16],xmm15
 %endif
-	GCM_COMPLETE	arg1, arg2, arg3, ENC
+	GCM_COMPLETE	arg1, arg2, arg3, arg4, ENC
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm15  , [rsp + 4*16]
@@ -1909,6 +1920,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_dec_finalize_avx_gen2(
 ;	 gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *auth_tag, /* Authenticated Tag output. */
 ;        u64     auth_tag_len); /* Authenticated Tag Length in bytes. Valid values are 16 (most likely), 12 or 8. */
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1926,7 +1938,7 @@ aesni_gcm128_dec_finalize_avx_gen2:
 	vmovdqu	[rsp + 3*16],xmm14
 	vmovdqu	[rsp + 4*16],xmm15
 %endif
-	GCM_COMPLETE	arg1, arg2, arg3, DEC
+	GCM_COMPLETE	arg1, arg2, arg3, arg4, DEC
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm15  , [rsp + 4*16]
@@ -1944,6 +1956,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_enc_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Ciphertext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Plaintext input */
 ;        u64     plaintext_len, /* Length of data in Bytes for encryption. */
@@ -1958,11 +1971,11 @@ aesni_gcm128_enc_avx_gen2:
 
 	FUNC_SAVE
 
-	GCM_INIT arg1, arg5, arg6, arg7
+	GCM_INIT arg1, arg2, arg6, arg7, arg8
 
-	GCM_ENC_DEC  arg1, arg2, arg3, arg4, ENC
+	GCM_ENC_DEC  arg1, arg2, arg3, arg4, arg5, ENC
 
-	GCM_COMPLETE arg1, arg8, arg9, ENC
+	GCM_COMPLETE arg1, arg2, arg9, arg10, ENC
 
 	FUNC_RESTORE
 
@@ -1971,6 +1984,7 @@ aesni_gcm128_enc_avx_gen2:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_dec_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Plaintext output. Decrypt in-place is allowed.  */
 ;        const   u8 *in, /* Ciphertext input */
 ;        u64     plaintext_len, /* Length of data in Bytes for encryption. */
@@ -1985,11 +1999,11 @@ aesni_gcm128_dec_avx_gen2:
 
 	FUNC_SAVE
 
-	GCM_INIT arg1, arg5, arg6, arg7
+	GCM_INIT arg1, arg2, arg6, arg7, arg8
 
-	GCM_ENC_DEC  arg1, arg2, arg3, arg4, DEC
+	GCM_ENC_DEC  arg1, arg2, arg3, arg4, arg5, DEC
 
-	GCM_COMPLETE arg1, arg8, arg9, DEC
+	GCM_COMPLETE arg1, arg2, arg9, arg10, DEC
 
 	FUNC_RESTORE
 

--- a/avx/gcm256_avx_gen2.asm
+++ b/avx/gcm256_avx_gen2.asm
@@ -381,21 +381,23 @@ default rel
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; PARTIAL_BLOCK: Handles encryption/decryption and the tag partial blocks between update calls.
 ; Requires the input data be at least 1 byte long.
-; Input: gcm_data struct* (GDATA), input text (PLAIN_CYPH_IN), input text length (PLAIN_CYPH_LEN),
-; the current data offset (DATA_OFFSET), and whether encoding or decoding (ENC_DEC)
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), input text (PLAIN_CYPH_IN),
+; input text length (PLAIN_CYPH_LEN), the current data offset (DATA_OFFSET), and whether
+; encoding or decoding (ENC_DEC)
 ; Output: A cypher of the first partial block (CYPH_PLAIN_OUT), and updated GDATA
 ; Clobbers rax, r10, r12, r13, r15, xmm0, xmm1, xmm2, xmm3, xmm5, xmm6, xmm9, xmm10, xmm11, xmm13
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro PARTIAL_BLOCK	7
+%macro PARTIAL_BLOCK	8
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%PLAIN_CYPH_LEN	%4
-%define	%%DATA_OFFSET		%5
-%define	%%AAD_HASH		%6
-%define	%%ENC_DEC		%7
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%PLAIN_CYPH_LEN	%5
+%define	%%DATA_OFFSET		%6
+%define	%%AAD_HASH		%7
+%define	%%ENC_DEC		%8
 
-	mov	r13, [%%GDATA + PBlockLen]
+	mov	r13, [%%GDATA_C + PBlockLen]
 	cmp	r13, 0
 	je	%%_partial_block_done		;Leave Macro if no partial blocks
 
@@ -411,7 +413,7 @@ default rel
 %%_data_read:				;Finished reading in data
 
 
-	vmovdqu	xmm9, [%%GDATA + PBlockEncKey]	;xmm9 = my_ctx_data.partial_block_enc_key
+	vmovdqu	xmm9, [%%GDATA_C + PBlockEncKey]	;xmm9 = my_comp_data.partial_block_enc_key
 	vmovdqu	xmm13, [%%GDATA + HashKey]
 
 	lea	r12, [SHIFT_MASK]
@@ -445,12 +447,12 @@ default rel
 
 	GHASH_MUL	%%AAD_HASH, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6	;GHASH computation for the last <16 Byte block
 	xor	rax,rax
-	mov	[%%GDATA+PBlockLen], rax
+	mov	[%%GDATA_C + PBlockLen], rax
 	jmp	%%_dec_done
 %%_partial_incomplete_1:
-	add	[%%GDATA+PBlockLen], %%PLAIN_CYPH_LEN
+	add	[%%GDATA_C + PBlockLen], %%PLAIN_CYPH_LEN
 %%_dec_done:
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH
 
 %else
 	vpxor	xmm9, xmm1	; Plaintext XOR E(K, Yn)
@@ -474,12 +476,12 @@ default rel
 
 	GHASH_MUL	%%AAD_HASH, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6	;GHASH computation for the last <16 Byte block
 	xor	rax,rax
-	mov	[%%GDATA+PBlockLen], rax
+	mov	[%%GDATA_C + PBlockLen], rax
 	jmp	%%_encode_done
 %%_partial_incomplete_2:
-	add [%%GDATA+PBlockLen], %%PLAIN_CYPH_LEN
+	add [%%GDATA_C + PBlockLen], %%PLAIN_CYPH_LEN
 %%_encode_done:
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH
 
 	vpshufb	xmm9, [SHUF_MASK]	; shuffle xmm9 back to output as ciphertext
 	vpshufb	xmm9, xmm2
@@ -524,35 +526,36 @@ default rel
 ; %%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r14 are used as a pointer only, not modified.
 ; Updated AAD_HASH is returned in %%T3
 
-%macro INITIAL_BLOCKS 23
+%macro INITIAL_BLOCKS 24
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%LENGTH		%4
-%define	%%DATA_OFFSET		%5
-%define	%%num_initial_blocks	%6      ; can be 0, 1, 2, 3, 4, 5, 6 or 7
-%define	%%T1		%7
-%define	%%HASH_KEY	%8
-%define	%%T3		%9
-%define	%%T4		%10
-%define	%%T5		%11
-%define	%%CTR		%12
-%define	%%XMM1		%13
-%define	%%XMM2		%14
-%define	%%XMM3		%15
-%define	%%XMM4		%16
-%define	%%XMM5		%17
-%define	%%XMM6		%18
-%define	%%XMM7		%19
-%define	%%XMM8		%20
-%define	%%T6		%21
-%define	%%T_key		%22
-%define	%%ENC_DEC	%23
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%LENGTH		%5
+%define	%%DATA_OFFSET		%6
+%define	%%num_initial_blocks	%7      ; can be 0, 1, 2, 3, 4, 5, 6 or 7
+%define	%%T1		%8
+%define	%%HASH_KEY	%9
+%define	%%T3		%10
+%define	%%T4		%11
+%define	%%T5		%12
+%define	%%CTR		%13
+%define	%%XMM1		%14
+%define	%%XMM2		%15
+%define	%%XMM3		%16
+%define	%%XMM4		%17
+%define	%%XMM5		%18
+%define	%%XMM6		%19
+%define	%%XMM7		%20
+%define	%%XMM8		%21
+%define	%%T6		%22
+%define	%%T_key		%23
+%define	%%ENC_DEC	%24
 
 %assign i (8-%%num_initial_blocks)
 		vmovdqu	reg(i), %%XMM8 ;move AAD_HASH to temp reg
 	        ; start AES for %%num_initial_blocks blocks
-	        vmovdqu  %%CTR, [%%GDATA + CurCount]                   ; %%CTR = Y0
+	        vmovdqu  %%CTR, [%%GDATA_C + CurCount]                   ; %%CTR = Y0
 
 
 %assign i (9-%%num_initial_blocks)
@@ -1442,16 +1445,17 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; GCM_INIT initializes a gcm_data struct to prepare for encoding/decoding.
-; Input: gcm_data struct* (GDATA), IV, Additional Authentication data (A_IN), Additional
-; Data length (A_LEN)
-; Output: Updated GDATA with the hash of A_IN (AadHash) and initialized other parts of GDATA.
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), IV, Additional
+; Authentication data (A_IN), Additional Data length (A_LEN)
+; Output: Updated GDATA_C with the hash of A_IN (AadHash) and initialized other parts of GDATA.
 ; Clobbers rax, r10-r13 and xmm0-xmm6
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_INIT 	4
+%macro	GCM_INIT 	5
 %define	%%GDATA		%1
-%define	%%IV		%2
-%define	%%A_IN		%3
-%define	%%A_LEN		%4
+%define	%%GDATA_C	%2
+%define	%%IV		%3
+%define	%%A_IN		%4
+%define	%%A_LEN		%5
 %define	%%AAD_HASH	xmm0
 %define	%%SUBHASH	xmm1
 
@@ -1462,19 +1466,19 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
 	vpxor	xmm2, xmm3
 	mov	r10, %%A_LEN
 
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH		; my_ctx_data.aad hash = aad_hash
-	mov	[%%GDATA + AadLen], r10			; my_ctx_data.aad_length = aad_length
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH	; my_comp_data.aad hash = aad_hash
+	mov	[%%GDATA_C + AadLen], r10		; my_comp_data.aad_length = aad_length
 	xor	r10, r10
-	mov	[%%GDATA + InLen], r10			; my_ctx_data.in_length = 0
-	mov	[%%GDATA + PBlockLen], r10		; my_ctx_data.partial_block_length = 0
-	vmovdqu	[%%GDATA + PBlockEncKey], xmm2		; my_ctx_data.partial_block_enc_key = 0
+	mov	[%%GDATA_C + InLen], r10		; my_comp_data.in_length = 0
+	mov	[%%GDATA_C + PBlockLen], r10		; my_comp_data.partial_block_length = 0
+	vmovdqu	[%%GDATA_C + PBlockEncKey], xmm2	; my_comp_data.partial_block_enc_key = 0
 	mov	r10, %%IV
 	vmovdqu	xmm2, [r10]
-	vmovdqu	[%%GDATA + OrigIV], xmm2		; my_ctx_data.orig_IV = iv
+	vmovdqu	[%%GDATA_C + OrigIV], xmm2		; my_comp_data.orig_IV = iv
 
 	vpshufb xmm2, [SHUF_MASK]
 
-	vmovdqu	[%%GDATA + CurCount], xmm2		; my_ctx_data.current_counter = iv
+	vmovdqu	[%%GDATA_C + CurCount], xmm2		; my_comp_data.current_counter = iv
 %endmacro
 
 
@@ -1482,17 +1486,18 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
 ; GCM_ENC_DEC Encodes/Decodes given data. Assumes that the passed gcm_data struct has been
 ; initialized by GCM_INIT
 ; Requires the input data be at least 1 byte long because of READ_SMALL_INPUT_DATA.
-; Input: gcm_data struct* (GDATA), input text (PLAIN_CYPH_IN), input text length (PLAIN_CYPH_LEN),
-; and whether encoding or decoding (ENC_DEC)
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), input text (PLAIN_CYPH_IN),
+; input text length (PLAIN_CYPH_LEN), and whether encoding or decoding (ENC_DEC)
 ; Output: A cypher of the given plain text (CYPH_PLAIN_OUT), and updated GDATA
 ; Clobbers rax, r10-r15, and xmm0-xmm15
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_ENC_DEC 		5
+%macro	GCM_ENC_DEC 		6
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%PLAIN_CYPH_LEN	%4
-%define	%%ENC_DEC		%5
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%PLAIN_CYPH_LEN	%5
+%define	%%ENC_DEC		%6
 %define	%%DATA_OFFSET		r11
 
 ; Macro flow:
@@ -1505,12 +1510,12 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
 	je	%%_multiple_of_16_bytes
 
 	xor %%DATA_OFFSET, %%DATA_OFFSET
-	add [%%GDATA+InLen], %%PLAIN_CYPH_LEN ;Update length of data processed
+	add [%%GDATA_C + InLen], %%PLAIN_CYPH_LEN ;Update length of data processed
 	vmovdqu  xmm13, [%%GDATA + HashKey]                 ; xmm13 = HashKey
-	vmovdqu xmm8, [%%GDATA + AadHash]
+	vmovdqu xmm8, [%%GDATA_C + AadHash]
 
 
-	PARTIAL_BLOCK %%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, %%PLAIN_CYPH_LEN, %%DATA_OFFSET, xmm8, %%ENC_DEC
+	PARTIAL_BLOCK %%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, %%PLAIN_CYPH_LEN, %%DATA_OFFSET, xmm8, %%ENC_DEC
 
 
 	mov	r13, %%PLAIN_CYPH_LEN
@@ -1540,42 +1545,42 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
         jmp     %%_initial_num_blocks_is_1
 
 %%_initial_num_blocks_is_7:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 7, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 7, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*7
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_6:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 6, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 6, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*6
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_5:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 5, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 5, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*5
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_4:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 4, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 4, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*4
         jmp     %%_initial_blocks_encrypted
 
 
 %%_initial_num_blocks_is_3:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 3, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 3, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*3
         jmp     %%_initial_blocks_encrypted
 %%_initial_num_blocks_is_2:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 2, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 2, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*2
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_1:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 1, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 1, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_0:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 0, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 0, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
 
 
 %%_initial_blocks_encrypted:
@@ -1627,22 +1632,22 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
 
 
 %%_zero_cipher_left:
-	vmovdqu	[%%GDATA + AadHash], xmm14		; my_ctx_data.aad hash = xmm14
-	vmovdqu	[%%GDATA + CurCount], xmm9		; my_ctx_data.current_counter = xmm9
+	vmovdqu	[%%GDATA_C + AadHash], xmm14		; my_comp_data.aad hash = xmm14
+	vmovdqu	[%%GDATA_C + CurCount], xmm9		; my_comp_data.current_counter = xmm9
 
         mov     r13, r10
         and     r13, 15                                 ; r13 = (%%PLAIN_CYPH_LEN mod 16)
 
         je      %%_multiple_of_16_bytes
 
-	mov	[%%GDATA + PBlockLen], r13		; my_ctx_data.partial_blck_length = r13
+	mov	[%%GDATA_C + PBlockLen], r13		; my_comp_data.partial_blck_length = r13
         ; handle the last <16 Byte block seperately
 
         vpaddd   xmm9, [ONE]                     ; INCR CNT to get Yn
-        vmovdqu [%%GDATA + CurCount], xmm9              ; my_ctx_data.current_counter = xmm9
+        vmovdqu [%%GDATA_C + CurCount], xmm9              ; my_comp_data.current_counter = xmm9
         vpshufb  xmm9, [SHUF_MASK]
         ENCRYPT_SINGLE_BLOCK   %%GDATA, xmm9             ; E(K, Yn)
-	vmovdqu	[%%GDATA + PBlockEncKey], xmm9		; my_ctx_data.partial_block_enc_key = xmm9
+	vmovdqu	[%%GDATA_C + PBlockEncKey], xmm9	; my_comp_data.partial_block_enc_key = xmm9
 
 	cmp	%%PLAIN_CYPH_LEN, 16
 	jge	%%_large_enough_update
@@ -1677,7 +1682,7 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
         vpand    xmm2, xmm1
         vpshufb  xmm2, [SHUF_MASK]
         vpxor    xmm14, xmm2
-	 vmovdqu	[%%GDATA + AadHash], xmm14
+	 vmovdqu	[%%GDATA_C + AadHash], xmm14
 
         %else
         vpxor    xmm9, xmm1                              ; Plaintext XOR E(K, Yn)
@@ -1685,7 +1690,7 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
         vpand    xmm9, xmm1                              ; mask out top 16-r13 bytes of xmm9
         vpshufb  xmm9, [SHUF_MASK]
         vpxor    xmm14, xmm9
-	vmovdqu	[%%GDATA + AadHash], xmm14
+	vmovdqu	[%%GDATA_C + AadHash], xmm14
 
         vpshufb  xmm9, [SHUF_MASK]               ; shuffle xmm9 back to output as ciphertext
         %endif
@@ -1719,19 +1724,21 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; GCM_COMPLETE Finishes Encyrption/Decryption of last partial block after GCM_UPDATE finishes.
-; Input: A gcm_data struct* (GDATA) and  whether encoding or decoding (ENC_DEC).
+; Input: A gcm_data struct* (GDATA)  with a gcm_data_comp struct* (GDATA_C) and whether
+; encoding or decoding (ENC_DEC).
 ; Output: Authorization Tag (AUTH_TAG) and Authorization Tag length (AUTH_TAG_LEN)
 ; Clobbers rax, r10-r12, and xmm0, xmm1, xmm5, xmm6, xmm9, xmm11, xmm14, xmm15
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_COMPLETE		4
+%macro	GCM_COMPLETE		5
 %define	%%GDATA			%1
-%define	%%AUTH_TAG		%2
-%define	%%AUTH_TAG_LEN		%3
-%define	%%ENC_DEC		%4
+%define	%%GDATA_C		%2
+%define	%%AUTH_TAG		%3
+%define	%%AUTH_TAG_LEN		%4
+%define	%%ENC_DEC		%5
 %define	%%PLAIN_CYPH_LEN	rax
 
-	mov	r12, [%%GDATA + PBlockLen]
-	vmovdqu	xmm14, [%%GDATA+AadHash]
+	mov	r12, [%%GDATA_C + PBlockLen]
+	vmovdqu	xmm14, [%%GDATA_C + AadHash]
 	vmovdqu xmm13, [%%GDATA+HashKey]
 
 	cmp	r12, 0
@@ -1739,12 +1746,12 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
 	je %%_partial_done
 
 	GHASH_MUL xmm14, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6 ;GHASH computation for the last <16 Byte block
-	vmovdqu [%%GDATA+AadHash], xmm14
+	vmovdqu [%%GDATA_C + AadHash], xmm14
 
 %%_partial_done:
 
-        mov     r12, [%%GDATA + AadLen]			; r12 = aadLen (number of bytes)
-	mov	%%PLAIN_CYPH_LEN, [%%GDATA+InLen]
+        mov     r12, [%%GDATA_C + AadLen]		; r12 = aadLen (number of bytes)
+	mov	%%PLAIN_CYPH_LEN, [%%GDATA_C + InLen]
 
         shl     r12, 3                                  ; convert into number of bits
         vmovd    xmm15, r12d                             ; len(A) in xmm15
@@ -1758,7 +1765,7 @@ vmovdqu  %%T_key, [%%GDATA+16*j]						; encrypt with last (14th) key round (12th
         GHASH_MUL       xmm14, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6    ; final GHASH computation
         vpshufb  xmm14, [SHUF_MASK]              ; perform a 16Byte swap
 
-        vmovdqu  xmm9, [%%GDATA+OrigIV]                            ; xmm9 = Y0
+        vmovdqu  xmm9, [%%GDATA_C + OrigIV]                            ; xmm9 = Y0
 
         ENCRYPT_SINGLE_BLOCK %%GDATA, xmm9                    ; E(K, Y0)
 
@@ -1859,6 +1866,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_init_avx_gen2( / aesni_gcm192_init_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *iv, /* Pre-counter block j0: 4 byte salt (from Security Association) concatenated with 8 byte Initialisation Vector (from IPSec ESP Payload) concatenated with 0x00000001. 16-byte pointer. */
 ;        const   u8 *aad, /* Additional Authentication Data (AAD)*/
 ;        u64     aad_len); /* Length of AAD in bytes (must be a multiple of 4 bytes). */
@@ -1878,7 +1886,7 @@ aesni_gcm256_init_avx_gen2:
 	vmovdqu	[rsp + 0*16],xmm6
 %endif
 
-	GCM_INIT arg1, arg2, arg3, arg4
+	GCM_INIT arg1, arg2, arg3, arg4, arg5
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm6 , [rsp + 0*16]
@@ -1893,6 +1901,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_enc_update_avx_gen2( / aesni_gcm192_enc_update_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Ciphertext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Plaintext input */
 ;        u64     plaintext_len); /* Length of data in Bytes for encryption. must be a multiple of 16 bytes*/
@@ -1906,7 +1915,7 @@ aesni_gcm256_enc_update_avx_gen2:
 %endif
 	FUNC_SAVE
 
-	GCM_ENC_DEC arg1, arg2, arg3, arg4, ENC
+	GCM_ENC_DEC arg1, arg2, arg3, arg4, arg5, ENC
 
 	FUNC_RESTORE
 
@@ -1916,6 +1925,7 @@ aesni_gcm256_enc_update_avx_gen2:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_dec_update_avx_gen2( / aesni_gcm192_dec_update_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Plaintext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Cyphertext input */
 ;        u64     plaintext_len); /* Length of data in Bytes for encryption. must be a multiple of 16 bytes*/
@@ -1930,7 +1940,7 @@ aesni_gcm256_dec_update_avx_gen2:
 
 	FUNC_SAVE
 
-	GCM_ENC_DEC arg1, arg2, arg3, arg4, DEC
+	GCM_ENC_DEC arg1, arg2, arg3, arg4, arg5, DEC
 
 	FUNC_RESTORE
 
@@ -1940,6 +1950,7 @@ aesni_gcm256_dec_update_avx_gen2:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_enc_finalize_avx_gen2( / aesni_gcm192_enc_finalize_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *auth_tag, /* Authenticated Tag output. */
 ;        u64     auth_tag_len); /* Authenticated Tag Length in bytes. Valid values are 16 (most likely), 12 or 8. */
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1962,7 +1973,7 @@ aesni_gcm256_enc_finalize_avx_gen2:
 	vmovdqu	[rsp + 3*16],xmm14
 	vmovdqu	[rsp + 4*16],xmm15
 %endif
-	GCM_COMPLETE	arg1, arg2, arg3, ENC
+	GCM_COMPLETE	arg1, arg2, arg3, arg4, ENC
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm15  , [rsp + 4*16]
@@ -1980,6 +1991,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_dec_finalize_avx_gen2( / aesni_gcm192_dec_finalize_avx_gen2(
 ;	 gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *auth_tag, /* Authenticated Tag output. */
 ;        u64     auth_tag_len); /* Authenticated Tag Length in bytes. Valid values are 16 (most likely), 12 or 8. */
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2002,7 +2014,7 @@ aesni_gcm256_dec_finalize_avx_gen2:
 	vmovdqu	[rsp + 3*16],xmm14
 	vmovdqu	[rsp + 4*16],xmm15
 %endif
-	GCM_COMPLETE	arg1, arg2, arg3, DEC
+	GCM_COMPLETE	arg1, arg2, arg3, arg4, DEC
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm15  , [rsp + 4*16]
@@ -2020,6 +2032,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_enc_avx_gen2( / aesni_gcm192_enc_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Ciphertext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Plaintext input */
 ;        u64     plaintext_len, /* Length of data in Bytes for encryption. */
@@ -2039,11 +2052,11 @@ aesni_gcm256_enc_avx_gen2:
 
 	FUNC_SAVE
 
-	GCM_INIT arg1, arg5, arg6, arg7
+	GCM_INIT arg1, arg2, arg6, arg7, arg8
 
-	GCM_ENC_DEC  arg1, arg2, arg3, arg4, ENC
+	GCM_ENC_DEC  arg1, arg2, arg3, arg4, arg5, ENC
 
-	GCM_COMPLETE arg1, arg8, arg9, ENC
+	GCM_COMPLETE arg1, arg2, arg9, arg10, ENC
 
 	FUNC_RESTORE
 
@@ -2052,6 +2065,7 @@ aesni_gcm256_enc_avx_gen2:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_dec_avx_gen2( / aesni_gcm192_dec_avx_gen2(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Plaintext output. Decrypt in-place is allowed.  */
 ;        const   u8 *in, /* Ciphertext input */
 ;        u64     plaintext_len, /* Length of data in Bytes for encryption. */
@@ -2071,11 +2085,11 @@ aesni_gcm256_dec_avx_gen2:
 
 	FUNC_SAVE
 
-	GCM_INIT arg1, arg5, arg6, arg7
+	GCM_INIT arg1, arg2, arg6, arg7, arg8
 
-	GCM_ENC_DEC  arg1, arg2, arg3, arg4, DEC
+	GCM_ENC_DEC  arg1, arg2, arg3, arg4, arg5, DEC
 
-	GCM_COMPLETE arg1, arg8, arg9, DEC
+	GCM_COMPLETE arg1, arg2, arg9, arg10, DEC
 
 	FUNC_RESTORE
 

--- a/avx2/gcm128_avx_gen4.asm
+++ b/avx2/gcm128_avx_gen4.asm
@@ -368,20 +368,22 @@ default rel
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; PARTIAL_BLOCK: Handles encryption/decryption and the tag partial blocks between update calls.
 ; Requires the input data be at least 1 byte long.
-; Input: gcm_data struct* (GDATA), input text (PLAIN_CYPH_IN), input text length (PLAIN_CYPH_LEN),
-; the current data offset (DATA_OFFSET), and whether encoding or decoding (ENC_DEC)
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), input text (PLAIN_CYPH_IN),
+; input text length (PLAIN_CYPH_LEN), the current data offset (DATA_OFFSET), and whether
+; encoding or decoding (ENC_DEC)
 ; Output: A cypher of the first partial block (CYPH_PLAIN_OUT), and updated GDATA
 ; Clobbers rax, r10, r12, r13, r15, xmm0, xmm1, xmm2, xmm3, xmm5, xmm6, xmm9, xmm10, xmm11, xmm13
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro PARTIAL_BLOCK	7
+%macro PARTIAL_BLOCK	8
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%PLAIN_CYPH_LEN	%4
-%define	%%DATA_OFFSET		%5
-%define	%%AAD_HASH		%6
-%define	%%ENC_DEC		%7
-	mov	r13, [%%GDATA + PBlockLen]
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%PLAIN_CYPH_LEN	%5
+%define	%%DATA_OFFSET		%6
+%define	%%AAD_HASH		%7
+%define	%%ENC_DEC		%8
+	mov	r13, [%%GDATA_C + PBlockLen]
 	cmp	r13, 0
 	je	%%_partial_block_done		;Leave Macro if no partial blocks
 
@@ -397,7 +399,7 @@ default rel
 %%_data_read:				;Finished reading in data
 
 
-	vmovdqu	xmm9, [%%GDATA + PBlockEncKey]	;xmm9 = my_ctx_data.partial_block_enc_key
+	vmovdqu	xmm9, [%%GDATA_C + PBlockEncKey]	;xmm9 = my_comp_data.partial_block_enc_key
 	vmovdqu	xmm13, [%%GDATA + HashKey]
 
 	lea	r12, [SHIFT_MASK]
@@ -431,12 +433,12 @@ default rel
 
 	GHASH_MUL	%%AAD_HASH, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6	;GHASH computation for the last <16 Byte block
 	xor	rax,rax
-	mov	[%%GDATA+PBlockLen], rax
+	mov	[%%GDATA_C + PBlockLen], rax
 	jmp	%%_dec_done
 %%_partial_incomplete_1:
-	add	[%%GDATA+PBlockLen], %%PLAIN_CYPH_LEN
+	add	[%%GDATA_C + PBlockLen], %%PLAIN_CYPH_LEN
 %%_dec_done:
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH
 
 %else
 	vpxor	xmm9, xmm1	; Plaintext XOR E(K, Yn)
@@ -460,12 +462,12 @@ default rel
 
 	GHASH_MUL	%%AAD_HASH, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6	;GHASH computation for the last <16 Byte block
 	xor	rax,rax
-	mov	[%%GDATA+PBlockLen], rax
+	mov	[%%GDATA_C + PBlockLen], rax
 	jmp	%%_encode_done
 %%_partial_incomplete_2:
-	add [%%GDATA+PBlockLen], %%PLAIN_CYPH_LEN
+	add [%%GDATA_C + PBlockLen], %%PLAIN_CYPH_LEN
 %%_encode_done:
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH
 
 	vpshufb	xmm9, [SHUF_MASK]	; shuffle xmm9 back to output as ciphertext
 	vpshufb	xmm9, xmm2
@@ -511,35 +513,36 @@ default rel
 ; %%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r14 are used as a pointer only, not modified.
 ; Updated AAD_HASH is returned in %%T3
 
-%macro INITIAL_BLOCKS 23
+%macro INITIAL_BLOCKS 24
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%LENGTH		%4
-%define	%%DATA_OFFSET		%5
-%define	%%num_initial_blocks	%6      ; can be 0, 1, 2, 3, 4, 5, 6 or 7
-%define	%%T1		%7
-%define	%%HASH_KEY	%8
-%define	%%T3		%9
-%define	%%T4		%10
-%define	%%T5		%11
-%define	%%CTR		%12
-%define	%%XMM1		%13
-%define	%%XMM2		%14
-%define	%%XMM3		%15
-%define	%%XMM4		%16
-%define	%%XMM5		%17
-%define	%%XMM6		%18
-%define	%%XMM7		%19
-%define	%%XMM8		%20
-%define	%%T6		%21
-%define	%%T_key		%22
-%define	%%ENC_DEC	%23
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%LENGTH		%5
+%define	%%DATA_OFFSET		%6
+%define	%%num_initial_blocks	%7      ; can be 0, 1, 2, 3, 4, 5, 6 or 7
+%define	%%T1		%8
+%define	%%HASH_KEY	%9
+%define	%%T3		%10
+%define	%%T4		%11
+%define	%%T5		%12
+%define	%%CTR		%13
+%define	%%XMM1		%14
+%define	%%XMM2		%15
+%define	%%XMM3		%16
+%define	%%XMM4		%17
+%define	%%XMM5		%18
+%define	%%XMM6		%19
+%define	%%XMM7		%20
+%define	%%XMM8		%21
+%define	%%T6		%22
+%define	%%T_key		%23
+%define	%%ENC_DEC	%24
 
 %assign i (8-%%num_initial_blocks)
 		vmovdqu	reg(i), %%XMM8 ;move AAD_HASH to temp reg
 		; start AES for %%num_initial_blocks blocks
-	        vmovdqu  %%CTR, [%%GDATA + CurCount]                   ; %%CTR = Y0
+	        vmovdqu  %%CTR, [%%GDATA_C + CurCount]                   ; %%CTR = Y0
 
 %assign i (9-%%num_initial_blocks)
 %rep %%num_initial_blocks
@@ -1388,16 +1391,17 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; GCM_INIT initializes a gcm_data struct to prepare for encoding/decoding.
-; Input: gcm_data struct* (GDATA), IV, Additional Authentication data (A_IN), Additional
-; Data length (A_LEN)
-; Output: Updated GDATA with the hash of A_IN (AadHash) and initialized other parts of GDATA.
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), IV, Additional
+; Authentication data (A_IN), Additional Data length (A_LEN)
+; Output: Updated GDATA_C with the hash of A_IN (AadHash) and initialized other parts of GDATA.
 ; Clobbers rax, r10-r13, and xmm0-xmm6
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_INIT 	4
+%macro	GCM_INIT 	5
 %define	%%GDATA		%1
-%define	%%IV		%2
-%define	%%A_IN		%3
-%define	%%A_LEN		%4
+%define	%%GDATA_C	%2
+%define	%%IV		%3
+%define	%%A_IN		%4
+%define	%%A_LEN		%5
 %define	%%AAD_HASH	xmm0
 %define	%%SUBHASH	xmm1
 
@@ -1408,19 +1412,19 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 	vpxor	xmm2, xmm3
 	mov	r10, %%A_LEN
 
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH		; my_ctx_data.aad hash = aad_hash
-	mov	[%%GDATA + AadLen], r10			; my_ctx_data.aad_length = aad_length
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH	; my_comp_data.aad hash = aad_hash
+	mov	[%%GDATA_C + AadLen], r10		; my_comp_data.aad_length = aad_length
 	xor	r10, r10
-	mov	[%%GDATA + InLen], r10			; my_ctx_data.in_length = 0
-	mov	[%%GDATA + PBlockLen], r10		; my_ctx_data.partial_block_length = 0
-	vmovdqu	[%%GDATA + PBlockEncKey], xmm2		; my_ctx_data.partial_block_enc_key = 0
+	mov	[%%GDATA_C + InLen], r10		; my_comp_data.in_length = 0
+	mov	[%%GDATA_C + PBlockLen], r10		; my_comp_data.partial_block_length = 0
+	vmovdqu	[%%GDATA_C + PBlockEncKey], xmm2	; my_comp_data.partial_block_enc_key = 0
 	mov	r10, %%IV
 	vmovdqu	xmm2, [r10]
-	vmovdqu	[%%GDATA + OrigIV], xmm2		; my_ctx_data.orig_IV = iv
+	vmovdqu	[%%GDATA_C + OrigIV], xmm2		; my_comp_data.orig_IV = iv
 
 	vpshufb xmm2, [SHUF_MASK]
 
-	vmovdqu	[%%GDATA + CurCount], xmm2		; my_ctx_data.current_counter = iv
+	vmovdqu	[%%GDATA_C + CurCount], xmm2		; my_comp_data.current_counter = iv
 %endmacro
 
 
@@ -1428,17 +1432,18 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 ; GCM_ENC_DEC Encodes/Decodes given data. Assumes that the passed gcm_data struct has been
 ; initialized by GCM_INIT
 ; Requires the input data be at least 1 byte long because of READ_SMALL_INPUT_DATA.
-; Input: gcm_data struct* (GDATA), input text (PLAIN_CYPH_IN), input text length (PLAIN_CYPH_LEN),
-; and whether encoding or decoding (ENC_DEC)
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), input text (PLAIN_CYPH_IN),
+; input text length (PLAIN_CYPH_LEN), and whether encoding or decoding (ENC_DEC)
 ; Output: A cypher of the given plain text (CYPH_PLAIN_OUT), and updated GDATA
 ; Clobbers rax, r10-r15, and xmm0-xmm15
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_ENC_DEC 		5
+%macro	GCM_ENC_DEC 		6
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%PLAIN_CYPH_LEN	%4
-%define	%%ENC_DEC		%5
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%PLAIN_CYPH_LEN	%5
+%define	%%ENC_DEC		%6
 %define	%%DATA_OFFSET		r11
 
 ; Macro flow:
@@ -1451,12 +1456,12 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 	je	%%_multiple_of_16_bytes
 
 	xor %%DATA_OFFSET, %%DATA_OFFSET
-	add [%%GDATA+InLen], %%PLAIN_CYPH_LEN ;Update length of data processed
+	add [%%GDATA_C + InLen], %%PLAIN_CYPH_LEN ;Update length of data processed
 	vmovdqu  xmm13, [%%GDATA + HashKey]                 ; xmm13 = HashKey
-	vmovdqu xmm8, [%%GDATA + AadHash]
+	vmovdqu xmm8, [%%GDATA_C + AadHash]
 
 
-	PARTIAL_BLOCK %%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, %%PLAIN_CYPH_LEN, %%DATA_OFFSET, xmm8, %%ENC_DEC
+	PARTIAL_BLOCK %%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, %%PLAIN_CYPH_LEN, %%DATA_OFFSET, xmm8, %%ENC_DEC
 
 
 	mov	r13, %%PLAIN_CYPH_LEN
@@ -1485,42 +1490,42 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
         jmp     %%_initial_num_blocks_is_1
 
 %%_initial_num_blocks_is_7:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 7, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 7, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*7
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_6:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 6, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 6, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*6
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_5:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 5, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 5, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*5
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_4:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 4, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 4, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*4
         jmp     %%_initial_blocks_encrypted
 
 
 %%_initial_num_blocks_is_3:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 3, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 3, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*3
         jmp     %%_initial_blocks_encrypted
 %%_initial_num_blocks_is_2:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 2, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 2, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*2
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_1:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 1, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 1, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_0:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 0, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 0, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
 
 
 %%_initial_blocks_encrypted:
@@ -1572,24 +1577,24 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 
 
 %%_zero_cipher_left:
-	vmovdqu	[%%GDATA + AadHash], xmm14		; my_ctx_data.aad hash = xmm14
-	vmovdqu	[%%GDATA + CurCount], xmm9		; my_ctx_data.current_counter = xmm9
+	vmovdqu	[%%GDATA_C + AadHash], xmm14		; my_comp_data.aad hash = xmm14
+	vmovdqu	[%%GDATA_C + CurCount], xmm9		; my_comp_data.current_counter = xmm9
 
         mov     r13, r10
         and     r13, 15                                 ; r13 = (%%PLAIN_CYPH_LEN mod 16)
 
         je      %%_multiple_of_16_bytes
 
-	mov	[%%GDATA + PBlockLen], r13		; my_ctx_data.partial_blck_length = r13
+	mov	[%%GDATA_C + PBlockLen], r13		; my_comp_data.partial_blck_length = r13
         ; handle the last <16 Byte block seperately
 
 
         vpaddd   xmm9, xmm9, [ONE]              ; INCR CNT to get Yn
-	vmovdqu	[%%GDATA + CurCount], xmm9
+	vmovdqu	[%%GDATA_C + CurCount], xmm9
 
         vpshufb  xmm9, [SHUF_MASK]
 	ENCRYPT_SINGLE_BLOCK	%%GDATA, xmm9                    ; E(K, Yn)
-	vmovdqu	[%%GDATA + PBlockEncKey], xmm9		; my_ctx_data.partial_block_enc_key = xmm9
+	vmovdqu	[%%GDATA_C + PBlockEncKey], xmm9	; my_comp_data.partial_block_enc_key = xmm9
 
 	cmp	%%PLAIN_CYPH_LEN, 16
 	jge	%%_large_enough_update
@@ -1624,14 +1629,14 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
         vpand    xmm2, xmm2, xmm1
         vpshufb  xmm2, [SHUF_MASK]
         vpxor    xmm14, xmm14, xmm2
-	 vmovdqu	[%%GDATA + AadHash], xmm14
+	 vmovdqu	[%%GDATA_C + AadHash], xmm14
         %else
         vpxor    xmm9, xmm9, xmm1                        ; Plaintext XOR E(K, Yn)
         vmovdqu  xmm1, [r12 + ALL_F - SHIFT_MASK]        ; get the appropriate mask to mask out top 16-r13 bytes of xmm9
         vpand    xmm9, xmm9, xmm1                        ; mask out top 16-r13 bytes of xmm9
         vpshufb  xmm9, [SHUF_MASK]
         vpxor    xmm14, xmm14, xmm9
-	vmovdqu	[%%GDATA + AadHash], xmm14
+	vmovdqu	[%%GDATA_C + AadHash], xmm14
         vpshufb  xmm9, [SHUF_MASK]               ; shuffle xmm9 back to output as ciphertext
         %endif
 
@@ -1664,19 +1669,21 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; GCM_COMPLETE Finishes Encyrption/Decryption of last partial block after GCM_UPDATE finishes.
-; Input: A gcm_data struct* (GDATA) and  whether encoding or decoding (ENC_DEC).
+; Input: A gcm_data struct* (GDATA)  with a gcm_data_comp struct* (GDATA_C) and whether
+; encoding or decoding (ENC_DEC).
 ; Output: Authorization Tag (AUTH_TAG) and Authorization Tag length (AUTH_TAG_LEN)
 ; Clobbers rax, r10-r12, and xmm0, xmm1, xmm5, xmm6, xmm9, xmm11, xmm14, xmm15
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_COMPLETE		4
+%macro	GCM_COMPLETE		5
 %define	%%GDATA			%1
-%define	%%AUTH_TAG		%2
-%define	%%AUTH_TAG_LEN		%3
-%define	%%ENC_DEC		%4
+%define	%%GDATA_C		%2
+%define	%%AUTH_TAG		%3
+%define	%%AUTH_TAG_LEN		%4
+%define	%%ENC_DEC		%5
 %define	%%PLAIN_CYPH_LEN	rax
 
-	mov	r12, [%%GDATA + PBlockLen]
-	vmovdqu	xmm14, [%%GDATA+AadHash]
+	mov	r12, [%%GDATA_C + PBlockLen]
+	vmovdqu	xmm14, [%%GDATA_C + AadHash]
 	vmovdqu xmm13, [%%GDATA+HashKey]
 
 	cmp	r12, 0
@@ -1684,12 +1691,12 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
 	je %%_partial_done
 
 	GHASH_MUL xmm14, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6 ;GHASH computation for the last <16 Byte block
-	vmovdqu [%%GDATA+AadHash], xmm14
+	vmovdqu [%%GDATA_C + AadHash], xmm14
 
 %%_partial_done:
 
-	mov	r12, [%%GDATA + AadLen]			; r12 = aadLen (number of bytes)
-	mov	%%PLAIN_CYPH_LEN, [%%GDATA+InLen]
+	mov	r12, [%%GDATA_C + AadLen]		; r12 = aadLen (number of bytes)
+	mov	%%PLAIN_CYPH_LEN, [%%GDATA_C + InLen]
 
         shl     r12, 3                                  ; convert into number of bits
         vmovd    xmm15, r12d                             ; len(A) in xmm15
@@ -1703,7 +1710,7 @@ vmovdqu  %%T_key, [%%GDATA+16*10]
         GHASH_MUL       xmm14, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6    ; final GHASH computation
         vpshufb  xmm14, [SHUF_MASK]              ; perform a 16Byte swap
 
-        vmovdqu xmm9, [%%GDATA + OrigIV]                             ; xmm9 = Y0
+        vmovdqu xmm9, [%%GDATA_C + OrigIV]                             ; xmm9 = Y0
 
         ENCRYPT_SINGLE_BLOCK %%GDATA, xmm9                    ; E(K, Y0)
 
@@ -1801,6 +1808,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_init_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *iv, /* Pre-counter block j0: 4 byte salt (from Security Association) concatenated with 8 byte Initialisation Vector (from IPSec ESP Payload) concatenated with 0x00000001. 16-byte pointer. */
 ;        const   u8 *aad, /* Additional Authentication Data (AAD)*/
 ;        u64     aad_len); /* Length of AAD in bytes (must be a multiple of 4 bytes). */
@@ -1815,7 +1823,7 @@ aesni_gcm128_init_avx_gen4:
 	vmovdqu	[rsp + 0*16],xmm6
 %endif
 
-	GCM_INIT arg1, arg2, arg3, arg4
+	GCM_INIT arg1, arg2, arg3, arg4, arg5
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm6 , [rsp + 0*16]
@@ -1830,6 +1838,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_enc_update_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Ciphertext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Plaintext input */
 ;        u64     plaintext_len); /* Length of data in Bytes for encryption. must be a multiple of 16 bytes*/
@@ -1839,7 +1848,7 @@ aesni_gcm128_enc_update_avx_gen4:
 
 	FUNC_SAVE
 
-	GCM_ENC_DEC arg1, arg2, arg3, arg4, ENC
+	GCM_ENC_DEC arg1, arg2, arg3, arg4, arg5, ENC
 
 	FUNC_RESTORE
 
@@ -1849,6 +1858,7 @@ aesni_gcm128_enc_update_avx_gen4:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_dec_update_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Plaintext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Cyphertext input */
 ;        u64     plaintext_len); /* Length of data in Bytes for encryption. must be a multiple of 16 bytes*/
@@ -1858,7 +1868,7 @@ aesni_gcm128_dec_update_avx_gen4:
 
 	FUNC_SAVE
 
-	GCM_ENC_DEC arg1, arg2, arg3, arg4, DEC
+	GCM_ENC_DEC arg1, arg2, arg3, arg4, arg5, DEC
 
 	FUNC_RESTORE
 
@@ -1868,6 +1878,7 @@ aesni_gcm128_dec_update_avx_gen4:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_enc_finalize_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *auth_tag, /* Authenticated Tag output. */
 ;        u64     auth_tag_len); /* Authenticated Tag Length in bytes. Valid values are 16 (most likely), 12 or 8. */
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1885,7 +1896,7 @@ aesni_gcm128_enc_finalize_avx_gen4:
 	vmovdqu	[rsp + 3*16],xmm14
 	vmovdqu	[rsp + 4*16],xmm15
 %endif
-	GCM_COMPLETE	arg1, arg2, arg3, ENC
+	GCM_COMPLETE	arg1, arg2, arg3, arg4, ENC
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm15  , [rsp + 4*16]
@@ -1903,6 +1914,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_dec_finalize_avx_gen4(
 ;	 gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *auth_tag, /* Authenticated Tag output. */
 ;        u64     auth_tag_len); /* Authenticated Tag Length in bytes. Valid values are 16 (most likely), 12 or 8. */
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1920,7 +1932,7 @@ aesni_gcm128_dec_finalize_avx_gen4:
 	vmovdqu	[rsp + 3*16],xmm14
 	vmovdqu	[rsp + 4*16],xmm15
 %endif
-	GCM_COMPLETE	arg1, arg2, arg3, DEC
+	GCM_COMPLETE	arg1, arg2, arg3, arg4, DEC
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm15  , [rsp + 4*16]
@@ -1938,6 +1950,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_enc_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Ciphertext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Plaintext input */
 ;        u64     plaintext_len, /* Length of data in Bytes for encryption. */
@@ -1952,11 +1965,11 @@ aesni_gcm128_enc_avx_gen4:
 
 	FUNC_SAVE
 
-	GCM_INIT arg1, arg5, arg6, arg7
+	GCM_INIT arg1, arg2, arg6, arg7, arg8
 
-	GCM_ENC_DEC  arg1, arg2, arg3, arg4, ENC
+	GCM_ENC_DEC  arg1, arg2, arg3, arg4, arg5, ENC
 
-	GCM_COMPLETE arg1, arg8, arg9, ENC
+	GCM_COMPLETE arg1, arg2, arg9, arg10, ENC
 
 	FUNC_RESTORE
 
@@ -1965,6 +1978,7 @@ aesni_gcm128_enc_avx_gen4:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_dec_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Plaintext output. Decrypt in-place is allowed.  */
 ;        const   u8 *in, /* Ciphertext input */
 ;        u64     plaintext_len, /* Length of data in Bytes for encryption. */
@@ -1979,11 +1993,11 @@ aesni_gcm128_dec_avx_gen4:
 
 	FUNC_SAVE
 
-	GCM_INIT arg1, arg5, arg6, arg7
+	GCM_INIT arg1, arg2, arg6, arg7, arg8
 
-	GCM_ENC_DEC  arg1, arg2, arg3, arg4, DEC
+	GCM_ENC_DEC  arg1, arg2, arg3, arg4, arg5, DEC
 
-	GCM_COMPLETE arg1, arg8, arg9, DEC
+	GCM_COMPLETE arg1, arg2, arg9, arg10, DEC
 
 	FUNC_RESTORE
 

--- a/avx2/gcm256_avx_gen4.asm
+++ b/avx2/gcm256_avx_gen4.asm
@@ -374,20 +374,22 @@ default rel
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; PARTIAL_BLOCK: Handles encryption/decryption and the tag partial blocks between update calls.
 ; Requires the input data be at least 1 byte long.
-; Input: gcm_data struct* (GDATA), input text (PLAIN_CYPH_IN), input text length (PLAIN_CYPH_LEN),
-; the current data offset (DATA_OFFSET), and whether encoding or decoding (ENC_DEC)
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), input text (PLAIN_CYPH_IN),
+; input text length (PLAIN_CYPH_LEN), the current data offset (DATA_OFFSET), and whether
+; encoding or decoding (ENC_DEC)
 ; Output: A cypher of the first partial block (CYPH_PLAIN_OUT), and updated GDATA
 ; Clobbers rax, r10, r12, r13, r15, xmm0, xmm1, xmm2, xmm3, xmm5, xmm6, xmm9, xmm10, xmm11, xmm13
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro PARTIAL_BLOCK	7
+%macro PARTIAL_BLOCK	8
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%PLAIN_CYPH_LEN	%4
-%define	%%DATA_OFFSET		%5
-%define	%%AAD_HASH		%6
-%define	%%ENC_DEC		%7
-	mov	r13, [%%GDATA + PBlockLen]
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%PLAIN_CYPH_LEN	%5
+%define	%%DATA_OFFSET		%6
+%define	%%AAD_HASH		%7
+%define	%%ENC_DEC		%8
+	mov	r13, [%%GDATA_C + PBlockLen]
 	cmp	r13, 0
 	je	%%_partial_block_done		;Leave Macro if no partial blocks
 
@@ -403,7 +405,7 @@ default rel
 %%_data_read:				;Finished reading in data
 
 
-	vmovdqu	xmm9, [%%GDATA + PBlockEncKey]	;xmm9 = my_ctx_data.partial_block_enc_key
+	vmovdqu	xmm9, [%%GDATA_C + PBlockEncKey]	;xmm9 = my_comp_data.partial_block_enc_key
 	vmovdqu	xmm13, [%%GDATA + HashKey]
 
 	lea	r12, [SHIFT_MASK]
@@ -437,12 +439,12 @@ default rel
 
 	GHASH_MUL	%%AAD_HASH, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6	;GHASH computation for the last <16 Byte block
 	xor	rax,rax
-	mov	[%%GDATA+PBlockLen], rax
+	mov	[%%GDATA_C + PBlockLen], rax
 	jmp	%%_dec_done
 %%_partial_incomplete_1:
-	add	[%%GDATA+PBlockLen], %%PLAIN_CYPH_LEN
+	add	[%%GDATA_C + PBlockLen], %%PLAIN_CYPH_LEN
 %%_dec_done:
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH
 
 %else
 	vpxor	xmm9, xmm1	; Plaintext XOR E(K, Yn)
@@ -466,12 +468,12 @@ default rel
 
 	GHASH_MUL	%%AAD_HASH, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6	;GHASH computation for the last <16 Byte block
 	xor	rax,rax
-	mov	[%%GDATA+PBlockLen], rax
+	mov	[%%GDATA_C + PBlockLen], rax
 	jmp	%%_encode_done
 %%_partial_incomplete_2:
-	add [%%GDATA+PBlockLen], %%PLAIN_CYPH_LEN
+	add [%%GDATA_C + PBlockLen], %%PLAIN_CYPH_LEN
 %%_encode_done:
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH
 
 	vpshufb	xmm9, [SHUF_MASK]	; shuffle xmm9 back to output as ciphertext
 	vpshufb	xmm9, xmm2
@@ -517,35 +519,36 @@ default rel
 ; %%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r14 are used as a pointer only, not modified.
 ; Updated AAD_HASH is returned in %%T3
 
-%macro INITIAL_BLOCKS 23
+%macro INITIAL_BLOCKS 24
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%LENGTH		%4
-%define	%%DATA_OFFSET		%5
-%define	%%num_initial_blocks	%6      ; can be 0, 1, 2, 3, 4, 5, 6 or 7
-%define	%%T1		%7
-%define	%%HASH_KEY	%8
-%define	%%T3		%9
-%define	%%T4		%10
-%define	%%T5		%11
-%define	%%CTR		%12
-%define	%%XMM1		%13
-%define	%%XMM2		%14
-%define	%%XMM3		%15
-%define	%%XMM4		%16
-%define	%%XMM5		%17
-%define	%%XMM6		%18
-%define	%%XMM7		%19
-%define	%%XMM8		%20
-%define	%%T6		%21
-%define	%%T_key		%22
-%define	%%ENC_DEC	%23
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%LENGTH		%5
+%define	%%DATA_OFFSET		%6
+%define	%%num_initial_blocks	%7      ; can be 0, 1, 2, 3, 4, 5, 6 or 7
+%define	%%T1		%8
+%define	%%HASH_KEY	%9
+%define	%%T3		%10
+%define	%%T4		%11
+%define	%%T5		%12
+%define	%%CTR		%13
+%define	%%XMM1		%14
+%define	%%XMM2		%15
+%define	%%XMM3		%16
+%define	%%XMM4		%17
+%define	%%XMM5		%18
+%define	%%XMM6		%19
+%define	%%XMM7		%20
+%define	%%XMM8		%21
+%define	%%T6		%22
+%define	%%T_key		%23
+%define	%%ENC_DEC	%24
 
 %assign i (8-%%num_initial_blocks)
 		vmovdqu	reg(i), %%XMM8 ;move AAD_HASH to temp reg
 		; start AES for %%num_initial_blocks blocks
-	        vmovdqu  %%CTR, [%%GDATA + CurCount]                   ; %%CTR = Y0
+	        vmovdqu  %%CTR, [%%GDATA_C + CurCount]                   ; %%CTR = Y0
 
 %assign i (9-%%num_initial_blocks)
 %rep %%num_initial_blocks
@@ -1436,16 +1439,17 @@ vmovdqu  %%T_key, [%%GDATA+16*j] 			; encrypt with last (14th) key round (12th f
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; GCM_INIT initializes a gcm_data struct to prepare for encoding/decoding.
-; Input: gcm_data struct* (GDATA), IV, Additional Authentication data (A_IN), Additional
-; Data length (A_LEN)
-; Output: Updated GDATA with the hash of A_IN (AadHash) and initialized other parts of GDATA.
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), IV, Additional
+; Authentication data (A_IN), Additional Data length (A_LEN)
+; Output: Updated GDATA_C with the hash of A_IN (AadHash) and initialized other parts of GDATA.
 ; Clobbers rax, r10-r13 and xmm0-xmm6
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_INIT 	4
+%macro	GCM_INIT 	5
 %define	%%GDATA		%1
-%define	%%IV		%2
-%define	%%A_IN		%3
-%define	%%A_LEN		%4
+%define	%%GDATA_C	%2
+%define	%%IV		%3
+%define	%%A_IN		%4
+%define	%%A_LEN		%5
 %define	%%AAD_HASH	xmm0
 %define	%%SUBHASH	xmm1
 
@@ -1456,19 +1460,19 @@ vmovdqu  %%T_key, [%%GDATA+16*j] 			; encrypt with last (14th) key round (12th f
 	vpxor	xmm2, xmm3
 	mov	r10, %%A_LEN
 
-	vmovdqu	[%%GDATA + AadHash], %%AAD_HASH		; my_ctx_data.aad hash = aad_hash
-	mov	[%%GDATA + AadLen], r10			; my_ctx_data.aad_length = aad_length
+	vmovdqu	[%%GDATA_C + AadHash], %%AAD_HASH	; my_comp_data.aad hash = aad_hash
+	mov	[%%GDATA_C + AadLen], r10		; my_comp_data.aad_length = aad_length
 	xor	r10, r10
-	mov	[%%GDATA + InLen], r10			; my_ctx_data.in_length = 0
-	mov	[%%GDATA + PBlockLen], r10		; my_ctx_data.partial_block_length = 0
-	vmovdqu	[%%GDATA + PBlockEncKey], xmm2		; my_ctx_data.partial_block_enc_key = 0
+	mov	[%%GDATA_C + InLen], r10		; my_comp_data.in_length = 0
+	mov	[%%GDATA_C + PBlockLen], r10		; my_comp_data.partial_block_length = 0
+	vmovdqu	[%%GDATA_C + PBlockEncKey], xmm2	; my_comp_data.partial_block_enc_key = 0
 	mov	r10, %%IV
 	vmovdqu	xmm2, [r10]
-	vmovdqu	[%%GDATA + OrigIV], xmm2		; my_ctx_data.orig_IV = iv
+	vmovdqu	[%%GDATA_C + OrigIV], xmm2		; my_comp_data.orig_IV = iv
 
 	vpshufb xmm2, [SHUF_MASK]
 
-	vmovdqu	[%%GDATA + CurCount], xmm2		; my_ctx_data.current_counter = iv
+	vmovdqu	[%%GDATA_C + CurCount], xmm2		; my_comp_data.current_counter = iv
 %endmacro
 
 
@@ -1476,17 +1480,18 @@ vmovdqu  %%T_key, [%%GDATA+16*j] 			; encrypt with last (14th) key round (12th f
 ; GCM_ENC_DEC Encodes/Decodes given data. Assumes that the passed gcm_data struct has been
 ; initialized by GCM_INIT
 ; Requires the input data be at least 1 byte long because of READ_SMALL_INPUT_DATA.
-; Input: gcm_data struct* (GDATA), input text (PLAIN_CYPH_IN), input text length (PLAIN_CYPH_LEN),
-; and whether encoding or decoding (ENC_DEC)
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), input text (PLAIN_CYPH_IN),
+; input text length (PLAIN_CYPH_LEN), and whether encoding or decoding (ENC_DEC)
 ; Output: A cypher of the given plain text (CYPH_PLAIN_OUT), and updated GDATA
 ; Clobbers rax, r10-r15, and xmm0-xmm15
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_ENC_DEC 		5
+%macro	GCM_ENC_DEC 		6
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%PLAIN_CYPH_LEN	%4
-%define	%%ENC_DEC		%5
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%PLAIN_CYPH_LEN	%5
+%define	%%ENC_DEC		%6
 %define	%%DATA_OFFSET		r11
 
 ; Macro flow:
@@ -1499,12 +1504,12 @@ vmovdqu  %%T_key, [%%GDATA+16*j] 			; encrypt with last (14th) key round (12th f
 	je	%%_multiple_of_16_bytes
 
 	xor %%DATA_OFFSET, %%DATA_OFFSET
-	add [%%GDATA+InLen], %%PLAIN_CYPH_LEN ;Update length of data processed
+	add [%%GDATA_C + InLen], %%PLAIN_CYPH_LEN ;Update length of data processed
 	vmovdqu  xmm13, [%%GDATA + HashKey]                 ; xmm13 = HashKey
-	vmovdqu xmm8, [%%GDATA + AadHash]
+	vmovdqu xmm8, [%%GDATA_C + AadHash]
 
 
-	PARTIAL_BLOCK %%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, %%PLAIN_CYPH_LEN, %%DATA_OFFSET, xmm8, %%ENC_DEC
+	PARTIAL_BLOCK %%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, %%PLAIN_CYPH_LEN, %%DATA_OFFSET, xmm8, %%ENC_DEC
 
 
 	mov	r13, %%PLAIN_CYPH_LEN
@@ -1533,42 +1538,42 @@ vmovdqu  %%T_key, [%%GDATA+16*j] 			; encrypt with last (14th) key round (12th f
         jmp     %%_initial_num_blocks_is_1
 
 %%_initial_num_blocks_is_7:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 7, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 7, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*7
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_6:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 6, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 6, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*6
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_5:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 5, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 5, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*5
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_4:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 4, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 4, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*4
         jmp     %%_initial_blocks_encrypted
 
 
 %%_initial_num_blocks_is_3:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 3, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 3, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*3
         jmp     %%_initial_blocks_encrypted
 %%_initial_num_blocks_is_2:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 2, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 2, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*2
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_1:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 1, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 1, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_0:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 0, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 0, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
 
 
 %%_initial_blocks_encrypted:
@@ -1620,24 +1625,24 @@ vmovdqu  %%T_key, [%%GDATA+16*j] 			; encrypt with last (14th) key round (12th f
 
 
 %%_zero_cipher_left:
-	vmovdqu	[%%GDATA + AadHash], xmm14		; my_ctx_data.aad hash = xmm14
-	vmovdqu	[%%GDATA + CurCount], xmm9		; my_ctx_data.current_counter = xmm9
+	vmovdqu	[%%GDATA_C + AadHash], xmm14		; my_comp_data.aad hash = xmm14
+	vmovdqu	[%%GDATA_C + CurCount], xmm9		; my_comp_data.current_counter = xmm9
 
         mov     r13, r10
         and     r13, 15                                 ; r13 = (%%PLAIN_CYPH_LEN mod 16)
 
         je      %%_multiple_of_16_bytes
 
-	mov	[%%GDATA + PBlockLen], r13		; my_ctx_data.partial_blck_length = r13
+	mov	[%%GDATA_C + PBlockLen], r13		; my_comp_data.partial_blck_length = r13
         ; handle the last <16 Byte block seperately
 
 
         vpaddd   xmm9, xmm9, [ONE]              ; INCR CNT to get Yn
-	vmovdqu	[%%GDATA + CurCount], xmm9
+	vmovdqu	[%%GDATA_C + CurCount], xmm9
 
         vpshufb  xmm9, [SHUF_MASK]
 	ENCRYPT_SINGLE_BLOCK	%%GDATA, xmm9                    ; E(K, Yn)
-	vmovdqu	[%%GDATA + PBlockEncKey], xmm9		; my_ctx_data.partial_block_enc_key = xmm9
+	vmovdqu	[%%GDATA_C + PBlockEncKey], xmm9	; my_comp_data.partial_block_enc_key = xmm9
 
 	cmp	%%PLAIN_CYPH_LEN, 16
 	jge	%%_large_enough_update
@@ -1672,14 +1677,14 @@ vmovdqu  %%T_key, [%%GDATA+16*j] 			; encrypt with last (14th) key round (12th f
         vpand    xmm2, xmm2, xmm1
         vpshufb  xmm2, [SHUF_MASK]
         vpxor    xmm14, xmm14, xmm2
-	 vmovdqu	[%%GDATA + AadHash], xmm14
+	 vmovdqu	[%%GDATA_C + AadHash], xmm14
         %else
         vpxor    xmm9, xmm9, xmm1                        ; Plaintext XOR E(K, Yn)
         vmovdqu  xmm1, [r12 + ALL_F - SHIFT_MASK]        ; get the appropriate mask to mask out top 16-r13 bytes of xmm9
         vpand    xmm9, xmm9, xmm1                        ; mask out top 16-r13 bytes of xmm9
         vpshufb  xmm9, [SHUF_MASK]
         vpxor    xmm14, xmm14, xmm9
-	vmovdqu	[%%GDATA + AadHash], xmm14
+	vmovdqu	[%%GDATA_C + AadHash], xmm14
         vpshufb  xmm9, [SHUF_MASK]               ; shuffle xmm9 back to output as ciphertext
         %endif
 
@@ -1712,19 +1717,21 @@ vmovdqu  %%T_key, [%%GDATA+16*j] 			; encrypt with last (14th) key round (12th f
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; GCM_COMPLETE Finishes Encyrption/Decryption of last partial block after GCM_UPDATE finishes.
-; Input: A gcm_data struct* (GDATA) and  whether encoding or decoding (ENC_DEC).
+; Input: A gcm_data struct* (GDATA)  with a gcm_data_comp struct* (GDATA_C) and whether
+; encoding or decoding (ENC_DEC).
 ; Output: Authorization Tag (AUTH_TAG) and Authorization Tag length (AUTH_TAG_LEN)
 ; Clobbers rax, r10-r12, and xmm0, xmm1, xmm5, xmm6, xmm9, xmm11, xmm14, xmm15
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_COMPLETE		4
+%macro	GCM_COMPLETE		5
 %define	%%GDATA			%1
-%define	%%AUTH_TAG		%2
-%define	%%AUTH_TAG_LEN		%3
-%define	%%ENC_DEC		%4
+%define	%%GDATA_C		%2
+%define	%%AUTH_TAG		%3
+%define	%%AUTH_TAG_LEN		%4
+%define	%%ENC_DEC		%5
 %define	%%PLAIN_CYPH_LEN	rax
 
-	mov	r12, [%%GDATA + PBlockLen]
-	vmovdqu	xmm14, [%%GDATA+AadHash]
+	mov	r12, [%%GDATA_C + PBlockLen]
+	vmovdqu	xmm14, [%%GDATA_C + AadHash]
 	vmovdqu xmm13, [%%GDATA+HashKey]
 
 	cmp	r12, 0
@@ -1732,12 +1739,12 @@ vmovdqu  %%T_key, [%%GDATA+16*j] 			; encrypt with last (14th) key round (12th f
 	je %%_partial_done
 
 	GHASH_MUL xmm14, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6 ;GHASH computation for the last <16 Byte block
-	vmovdqu [%%GDATA+AadHash], xmm14
+	vmovdqu [%%GDATA_C + AadHash], xmm14
 
 %%_partial_done:
 
-	mov	r12, [%%GDATA + AadLen]			; r12 = aadLen (number of bytes)
-	mov	%%PLAIN_CYPH_LEN, [%%GDATA+InLen]
+	mov	r12, [%%GDATA_C + AadLen]		; r12 = aadLen (number of bytes)
+	mov	%%PLAIN_CYPH_LEN, [%%GDATA_C + InLen]
 
         shl     r12, 3                                  ; convert into number of bits
         vmovd    xmm15, r12d                             ; len(A) in xmm15
@@ -1751,7 +1758,7 @@ vmovdqu  %%T_key, [%%GDATA+16*j] 			; encrypt with last (14th) key round (12th f
         GHASH_MUL       xmm14, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6    ; final GHASH computation
         vpshufb  xmm14, [SHUF_MASK]              ; perform a 16Byte swap
 
-        vmovdqu xmm9, [%%GDATA + OrigIV]                             ; xmm9 = Y0
+        vmovdqu xmm9, [%%GDATA_C + OrigIV]                             ; xmm9 = Y0
 
         ENCRYPT_SINGLE_BLOCK %%GDATA, xmm9                    ; E(K, Y0)
 
@@ -1854,6 +1861,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_init_avx_gen4( / aesni_gcm192_init_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *iv, /* Pre-counter block j0: 4 byte salt (from Security Association) concatenated with 8 byte Initialisation Vector (from IPSec ESP Payload) concatenated with 0x00000001. 16-byte pointer. */
 ;        const   u8 *aad, /* Additional Authentication Data (AAD)*/
 ;        u64     aad_len); /* Length of AAD in bytes (must be a multiple of 4 bytes). */
@@ -1873,7 +1881,7 @@ aesni_gcm256_init_avx_gen4:
 	vmovdqu	[rsp + 0*16],xmm6
 %endif
 
-	GCM_INIT arg1, arg2, arg3, arg4
+	GCM_INIT arg1, arg2, arg3, arg4, arg5
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm6 , [rsp + 0*16]
@@ -1887,6 +1895,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_enc_update_avx_gen4( / aesni_gcm192_enc_update_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Ciphertext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Plaintext input */
 ;        u64     plaintext_len); /* Length of data in Bytes for encryption. must be a multiple of 16 bytes*/
@@ -1901,7 +1910,7 @@ aesni_gcm256_enc_update_avx_gen4:
 
 	FUNC_SAVE
 
-	GCM_ENC_DEC arg1, arg2, arg3, arg4, ENC
+	GCM_ENC_DEC arg1, arg2, arg3, arg4, arg5, ENC
 
 	FUNC_RESTORE
 
@@ -1911,6 +1920,7 @@ aesni_gcm256_enc_update_avx_gen4:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_dec_update_avx_gen4( / aesni_gcm192_dec_update_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Plaintext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Cyphertext input */
 ;        u64     plaintext_len); /* Length of data in Bytes for encryption. must be a multiple of 16 bytes*/
@@ -1925,7 +1935,7 @@ aesni_gcm256_dec_update_avx_gen4:
 
 	FUNC_SAVE
 
-	GCM_ENC_DEC arg1, arg2, arg3, arg4, DEC
+	GCM_ENC_DEC arg1, arg2, arg3, arg4, arg5, DEC
 
 	FUNC_RESTORE
 
@@ -1935,6 +1945,7 @@ aesni_gcm256_dec_update_avx_gen4:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_enc_finalize_avx_gen4( / aesni_gcm192_enc_finalize_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *auth_tag, /* Authenticated Tag output. */
 ;        u64     auth_tag_len); /* Authenticated Tag Length in bytes. Valid values are 16 (most likely), 12 or 8. */
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1957,7 +1968,7 @@ aesni_gcm256_enc_finalize_avx_gen4:
 	vmovdqu	[rsp + 3*16],xmm14
 	vmovdqu	[rsp + 4*16],xmm15
 %endif
-	GCM_COMPLETE	arg1, arg2, arg3, ENC
+	GCM_COMPLETE	arg1, arg2, arg3, arg4, ENC
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm15  , [rsp + 4*16]
@@ -1975,6 +1986,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_dec_finalize_avx_gen4( / aesni_gcm192_dec_finalize_avx_gen4(
 ;	 gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *auth_tag, /* Authenticated Tag output. */
 ;        u64     auth_tag_len); /* Authenticated Tag Length in bytes. Valid values are 16 (most likely), 12 or 8. */
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1997,7 +2009,7 @@ aesni_gcm256_dec_finalize_avx_gen4:
 	vmovdqu	[rsp + 3*16],xmm14
 	vmovdqu	[rsp + 4*16],xmm15
 %endif
-	GCM_COMPLETE	arg1, arg2, arg3, DEC
+	GCM_COMPLETE	arg1, arg2, arg3, arg4, DEC
 
 %ifidn __OUTPUT_FORMAT__, win64
 	vmovdqu	xmm15  , [rsp + 4*16]
@@ -2015,6 +2027,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_enc_avx_gen4( / aesni_gcm192_enc_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Ciphertext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Plaintext input */
 ;        u64     plaintext_len, /* Length of data in Bytes for encryption. */
@@ -2034,11 +2047,11 @@ aesni_gcm256_enc_avx_gen4:
 
 	FUNC_SAVE
 
-	GCM_INIT arg1, arg5, arg6, arg7
+	GCM_INIT arg1, arg2, arg6, arg7, arg8
 
-	GCM_ENC_DEC  arg1, arg2, arg3, arg4, ENC
+	GCM_ENC_DEC  arg1, arg2, arg3, arg4, arg5, ENC
 
-	GCM_COMPLETE arg1, arg8, arg9, ENC
+	GCM_COMPLETE arg1, arg2, arg9, arg10, ENC
 
 	FUNC_RESTORE
 
@@ -2047,6 +2060,7 @@ aesni_gcm256_enc_avx_gen4:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm256_dec_avx_gen4( / aesni_gcm192_dec_avx_gen4(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Plaintext output. Decrypt in-place is allowed.  */
 ;        const   u8 *in, /* Ciphertext input */
 ;        u64     plaintext_len, /* Length of data in Bytes for encryption. */
@@ -2066,11 +2080,11 @@ aesni_gcm256_dec_avx_gen4:
 
 	FUNC_SAVE
 
-	GCM_INIT arg1, arg5, arg6, arg7
+	GCM_INIT arg1, arg2, arg6, arg7, arg8
 
-	GCM_ENC_DEC  arg1, arg2, arg3, arg4, DEC
+	GCM_ENC_DEC  arg1, arg2, arg3, arg4, arg5, DEC
 
-	GCM_COMPLETE arg1, arg8, arg9, DEC
+	GCM_COMPLETE arg1, arg2, arg9, arg10, DEC
 
 	FUNC_RESTORE
 

--- a/sse/gcm128_sse.asm
+++ b/sse/gcm128_sse.asm
@@ -392,20 +392,22 @@ default rel
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; PARTIAL_BLOCK: Handles encryption/decryption and the tag partial blocks between update calls.
 ; Requires the input data be at least 1 byte long.
-; Input: gcm_data struct* (GDATA), input text (PLAIN_CYPH_IN), input text length (PLAIN_CYPH_LEN),
-; the current data offset (DATA_OFFSET), and whether encoding or decoding (ENC_DEC)
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), input text (PLAIN_CYPH_IN),
+; input text length (PLAIN_CYPH_LEN), the current data offset (DATA_OFFSET), and whether
+; encoding or decoding (ENC_DEC)
 ; Output: A cypher of the first partial block (CYPH_PLAIN_OUT), and updated GDATA
 ; Clobbers rax, r10, r12, r13, r15, xmm0, xmm1, xmm2, xmm3, xmm5, xmm6, xmm9, xmm10, xmm11, xmm13
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro PARTIAL_BLOCK	7
+%macro PARTIAL_BLOCK	8
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%PLAIN_CYPH_LEN	%4
-%define	%%DATA_OFFSET		%5
-%define	%%AAD_HASH		%6
-%define	%%ENC_DEC		%7
-	mov	r13, [%%GDATA + PBlockLen]
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%PLAIN_CYPH_LEN	%5
+%define	%%DATA_OFFSET		%6
+%define	%%AAD_HASH		%7
+%define	%%ENC_DEC		%8
+	mov	r13, [%%GDATA_C + PBlockLen]
 	cmp	r13, 0
 	je	%%_partial_block_done		;Leave Macro if no partial blocks
 
@@ -421,7 +423,7 @@ default rel
 %%_data_read:					;Finished reading in data
 
 
-	movdqu	xmm9, [%%GDATA + PBlockEncKey]	;xmm9 = my_ctx_data.partial_block_enc_key
+	movdqu	xmm9, [%%GDATA_C + PBlockEncKey]	;xmm9 = my_comp_data.partial_block_enc_key
 	movdqu	xmm13, [%%GDATA + HashKey]
 
 	lea	r12, [SHIFT_MASK]
@@ -455,12 +457,12 @@ default rel
 
 	GHASH_MUL	%%AAD_HASH, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6	;GHASH computation for the last <16 Byte block
 	xor	rax,rax
-	mov	[%%GDATA+PBlockLen], rax
+	mov	[%%GDATA_C + PBlockLen], rax
 	jmp	%%_dec_done
 %%_partial_incomplete_1:
-	add	[%%GDATA+PBlockLen], %%PLAIN_CYPH_LEN
+	add	[%%GDATA_C + PBlockLen], %%PLAIN_CYPH_LEN
 %%_dec_done:
-	movdqu	[%%GDATA + AadHash], %%AAD_HASH
+	movdqu	[%%GDATA_C + AadHash], %%AAD_HASH
 
 %else
 	pxor	xmm9, xmm1	; Plaintext XOR E(K, Yn)
@@ -484,12 +486,12 @@ default rel
 
 	GHASH_MUL	%%AAD_HASH, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6	;GHASH computation for the last <16 Byte block
 	xor	rax,rax
-	mov	[%%GDATA+PBlockLen], rax
+	mov	[%%GDATA_C + PBlockLen], rax
 	jmp	%%_encode_done
 %%_partial_incomplete_2:
-	add [%%GDATA+PBlockLen], %%PLAIN_CYPH_LEN
+	add [%%GDATA_C + PBlockLen], %%PLAIN_CYPH_LEN
 %%_encode_done:
-	movdqu	[%%GDATA + AadHash], %%AAD_HASH
+	movdqu	[%%GDATA_C + AadHash], %%AAD_HASH
 
 	pshufb	xmm9, [SHUF_MASK]	; shuffle xmm9 back to output as ciphertext
 	pshufb	xmm9, xmm2
@@ -535,36 +537,37 @@ default rel
 ; %%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r14 are used as a pointer only, not modified
 ; Updated AAD_HASH is returned in %%T3
 
-%macro INITIAL_BLOCKS 23
+%macro INITIAL_BLOCKS 24
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%LENGTH		%4
-%define	%%DATA_OFFSET		%5
-%define	%%num_initial_blocks	%6	; can be 0, 1, 2, 3, 4, 5, 6 or 7
-%define	%%T1		%7
-%define	%%HASH_KEY	%8
-%define	%%T3		%9
-%define	%%T4		%10
-%define	%%T5		%11
-%define	%%CTR		%12
-%define	%%XMM1		%13
-%define	%%XMM2		%14
-%define	%%XMM3		%15
-%define	%%XMM4		%16
-%define	%%XMM5		%17
-%define	%%XMM6		%18
-%define	%%XMM7		%19
-%define	%%XMM8		%20
-%define	%%T6		%21
-%define	%%T_key		%22
-%define	%%ENC_DEC	%23
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%LENGTH		%5
+%define	%%DATA_OFFSET		%6
+%define	%%num_initial_blocks	%7      ; can be 0, 1, 2, 3, 4, 5, 6 or 7
+%define	%%T1		%8
+%define	%%HASH_KEY	%9
+%define	%%T3		%10
+%define	%%T4		%11
+%define	%%T5		%12
+%define	%%CTR		%13
+%define	%%XMM1		%14
+%define	%%XMM2		%15
+%define	%%XMM3		%16
+%define	%%XMM4		%17
+%define	%%XMM5		%18
+%define	%%XMM6		%19
+%define	%%XMM7		%20
+%define	%%XMM8		%21
+%define	%%T6		%22
+%define	%%T_key		%23
+%define	%%ENC_DEC	%24
 
 %assign i       (8-%%num_initial_blocks)
 		movdqu	reg(i), %%XMM8	; move AAD_HASH to temp reg
 
 	        ; start AES for %%num_initial_blocks blocks
-	        movdqu  %%CTR, [%%GDATA + CurCount]	; %%CTR = Y0
+	        movdqu  %%CTR, [%%GDATA_C + CurCount]	; %%CTR = Y0
 
 
 %assign i (9-%%num_initial_blocks)
@@ -1436,16 +1439,17 @@ movdqu  %%T_key, [%%GDATA+16*10]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; GCM_INIT initializes a gcm_data struct to prepare for encoding/decoding.
-; Input: gcm_data struct* (GDATA), IV, Additional Authentication data (A_IN), Additional
-; Data length (A_LEN)
-; Output: Updated GDATA with the hash of A_IN (AadHash) and initialized other parts of GDATA.
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), IV, Additional
+; Authentication data (A_IN), Additional Data length (A_LEN)
+; Output: Updated GDATA_C with the hash of A_IN (AadHash) and initialized other parts of GDATA.
 ; Clobbers rax, r10-r13, and xmm0-xmm6
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro  GCM_INIT 	4
-%define %%GDATA		%1
-%define %%IV		%2
-%define %%A_IN		%3
-%define %%A_LEN		%4
+%macro	GCM_INIT 	5
+%define	%%GDATA		%1
+%define	%%GDATA_C	%2
+%define	%%IV		%3
+%define	%%A_IN		%4
+%define	%%A_LEN		%5
 %define %%AAD_HASH	xmm0
 %define %%SUBHASH	xmm1
 
@@ -1456,19 +1460,19 @@ movdqu  %%T_key, [%%GDATA+16*10]
 	pxor	xmm2, xmm3
 	mov	r10, %%A_LEN
 
-	movdqu	[%%GDATA + AadHash], %%AAD_HASH		; my_ctx_data.aad hash = aad_hash
-	mov	[%%GDATA + AadLen], r10			; my_ctx_data.aad_length = aad_length
+	movdqu	[%%GDATA_C + AadHash], %%AAD_HASH	; my_comp_data.aad hash = aad_hash
+	mov	[%%GDATA_C + AadLen], r10		; my_comp_data.aad_length = aad_length
 	xor	r10, r10
-	mov	[%%GDATA + InLen], r10			; my_ctx_data.in_length = 0
-	mov	[%%GDATA + PBlockLen], r10		; my_ctx_data.partial_block_length = 0
-	movdqu	[%%GDATA + PBlockEncKey], xmm2		; my_ctx_data.partial_block_enc_key = 0
+	mov	[%%GDATA_C + InLen], r10		; my_comp_data.in_length = 0
+	mov	[%%GDATA_C + PBlockLen], r10		; my_comp_data.partial_block_length = 0
+	movdqu	[%%GDATA_C + PBlockEncKey], xmm2	; my_comp_data.partial_block_enc_key = 0
 	mov	r10, %%IV
 	movdqu	xmm2, [r10]
-	movdqu	[%%GDATA + OrigIV], xmm2		; my_ctx_data.orig_IV = iv
+	movdqu	[%%GDATA_C + OrigIV], xmm2		; my_comp_data.orig_IV = iv
 
 	pshufb xmm2, [SHUF_MASK]
 
-	movdqu	[%%GDATA + CurCount], xmm2		; my_ctx_data.current_counter = iv
+	movdqu	[%%GDATA_C + CurCount], xmm2		; my_comp_data.current_counter = iv
 %endmacro
 
 
@@ -1476,17 +1480,18 @@ movdqu  %%T_key, [%%GDATA+16*10]
 ; GCM_ENC_DEC Encodes/Decodes given data. Assumes that the passed gcm_data struct has been
 ; initialized by GCM_INIT
 ; Requires the input data be at least 1 byte long because of READ_SMALL_INPUT_DATA.
-; Input: gcm_data struct* (GDATA), input text (PLAIN_CYPH_IN), input text length (PLAIN_CYPH_LEN),
-; and whether encoding or decoding (ENC_DEC)
+; Input: gcm_data struct* (GDATA), gcm_data_comp struct* (GDATA_C), input text (PLAIN_CYPH_IN),
+; input text length (PLAIN_CYPH_LEN), and whether encoding or decoding (ENC_DEC)
 ; Output: A cypher of the given plain text (CYPH_PLAIN_OUT), and updated GDATA
 ; Clobbers rax, r10-r15, and xmm0-xmm15
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_ENC_DEC		5
+%macro	GCM_ENC_DEC 		6
 %define	%%GDATA			%1
-%define	%%CYPH_PLAIN_OUT	%2
-%define	%%PLAIN_CYPH_IN		%3
-%define	%%PLAIN_CYPH_LEN	%4
-%define	%%ENC_DEC		%5
+%define	%%GDATA_C		%2
+%define	%%CYPH_PLAIN_OUT	%3
+%define	%%PLAIN_CYPH_IN		%4
+%define	%%PLAIN_CYPH_LEN	%5
+%define	%%ENC_DEC		%6
 %define	%%DATA_OFFSET		r11
 
 ; Macro flow:
@@ -1499,12 +1504,12 @@ movdqu  %%T_key, [%%GDATA+16*10]
 	je	%%_multiple_of_16_bytes
 
 	xor	%%DATA_OFFSET, %%DATA_OFFSET
-	add	[%%GDATA+InLen], %%PLAIN_CYPH_LEN ;Update length of data processed
+	add	[%%GDATA_C + InLen], %%PLAIN_CYPH_LEN ;Update length of data processed
 	movdqu	xmm13, [%%GDATA + HashKey]                 ; xmm13 = HashKey
-	movdqu	xmm8, [%%GDATA + AadHash]
+	movdqu	xmm8, [%%GDATA_C + AadHash]
 
 
-	PARTIAL_BLOCK %%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, %%PLAIN_CYPH_LEN, %%DATA_OFFSET, xmm8, %%ENC_DEC
+	PARTIAL_BLOCK %%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, %%PLAIN_CYPH_LEN, %%DATA_OFFSET, xmm8, %%ENC_DEC
 
         mov     r13, %%PLAIN_CYPH_LEN                               ; save the number of bytes of plaintext/ciphertext
 	sub	r13, %%DATA_OFFSET
@@ -1532,42 +1537,42 @@ movdqu  %%T_key, [%%GDATA+16*10]
         jmp     %%_initial_num_blocks_is_1
 
 %%_initial_num_blocks_is_7:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 7, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 7, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*7
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_6:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 6, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 6, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*6
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_5:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 5, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 5, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*5
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_4:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 4, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 4, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*4
         jmp     %%_initial_blocks_encrypted
 
 
 %%_initial_num_blocks_is_3:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 3, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 3, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*3
         jmp     %%_initial_blocks_encrypted
 %%_initial_num_blocks_is_2:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 2, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 2, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16*2
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_1:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 1, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 1, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
         sub     r13, 16
         jmp     %%_initial_blocks_encrypted
 
 %%_initial_num_blocks_is_0:
-	INITIAL_BLOCKS	%%GDATA, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 0, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
+	INITIAL_BLOCKS	%%GDATA, %%GDATA_C, %%CYPH_PLAIN_OUT, %%PLAIN_CYPH_IN, r13, %%DATA_OFFSET, 0, xmm12, xmm13, xmm14, xmm15, xmm11, xmm9, xmm1, xmm2, xmm3, xmm4, xmm5, xmm6, xmm7, xmm8, xmm10, xmm0, %%ENC_DEC
 
 
 %%_initial_blocks_encrypted:
@@ -1619,22 +1624,22 @@ movdqu  %%T_key, [%%GDATA+16*10]
 
 
 %%_zero_cipher_left:
-	movdqu	[%%GDATA + AadHash], xmm14
-	movdqu	[%%GDATA + CurCount], xmm9
+	movdqu	[%%GDATA_C + AadHash], xmm14
+	movdqu	[%%GDATA_C + CurCount], xmm9
 
         mov     r13, r10
         and     r13, 15                                ; r13 = (%%PLAIN_CYPH_LEN mod 16)
 
         je      %%_multiple_of_16_bytes
 
-	mov	[%%GDATA + PBlockLen], r13		; my_ctx.data.partial_blck_length = r13
+	mov	[%%GDATA_C + PBlockLen], r13		; my_comp.data.partial_blck_length = r13
         ; handle the last <16 Byte block seperately
 
         paddd   xmm9, [ONE]                     ; INCR CNT to get Yn
-	movdqu	[%%GDATA + CurCount], xmm9		; my_ctx.data.current_counter = xmm9
+	movdqu	[%%GDATA_C + CurCount], xmm9		; my_comp.data.current_counter = xmm9
         pshufb  xmm9, [SHUF_MASK]
 	ENCRYPT_SINGLE_BLOCK	%%GDATA, xmm9, xmm2     ; E(K, Yn)
-	movdqu	[%%GDATA + PBlockEncKey], xmm9		; my_ctx_data.partial_block_enc_key = xmm9
+	movdqu	[%%GDATA_C + PBlockEncKey], xmm9	; my_comp_data.partial_block_enc_key = xmm9
 
 	cmp	%%PLAIN_CYPH_LEN, 16
 	jge	%%_large_enough_update
@@ -1667,7 +1672,7 @@ movdqu  %%T_key, [%%GDATA+16*10]
         pand    xmm2, xmm1
         pshufb  xmm2, [SHUF_MASK]
         pxor    xmm14, xmm2
-	movdqu	[%%GDATA + AadHash], xmm14
+	movdqu	[%%GDATA_C + AadHash], xmm14
 
         %else
         pxor    xmm9, xmm1                              ; Plaintext XOR E(K, Yn)
@@ -1675,7 +1680,7 @@ movdqu  %%T_key, [%%GDATA+16*10]
         pand    xmm9, xmm1                              ; mask out top 16-r13 bytes of xmm9
         pshufb  xmm9, [SHUF_MASK]
         pxor    xmm14, xmm9
-	movdqu	[%%GDATA + AadHash], xmm14
+	movdqu	[%%GDATA_C + AadHash], xmm14
 
         pshufb  xmm9, [SHUF_MASK]               ; shuffle xmm9 back to output as ciphertext
         %endif
@@ -1708,19 +1713,21 @@ movdqu  %%T_key, [%%GDATA+16*10]
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; GCM_COMPLETE Finishes Encyrption/Decryption of last partial block after GCM_UPDATE finishes.
-; Input: A gcm_data struct* (GDATA) and  whether encoding or decoding (ENC_DEC).
+; Input: A gcm_data struct* (GDATA)  with a gcm_data_comp struct* (GDATA_C) and whether
+; encoding or decoding (ENC_DEC).
 ; Output: Authorization Tag (AUTH_TAG) and Authorization Tag length (AUTH_TAG_LEN)
 ; Clobbers rax, r10-r12, and xmm0, xmm1, xmm5, xmm6, xmm9, xmm11, xmm14, xmm15
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-%macro	GCM_COMPLETE		4
+%macro	GCM_COMPLETE		5
 %define	%%GDATA			%1
-%define	%%AUTH_TAG		%2
-%define	%%AUTH_TAG_LEN		%3
-%define	%%ENC_DEC		%4
+%define	%%GDATA_C		%2
+%define	%%AUTH_TAG		%3
+%define	%%AUTH_TAG_LEN		%4
+%define	%%ENC_DEC		%5
 %define	%%PLAIN_CYPH_LEN	rax
 
-        mov     r12, [%%GDATA + PBlockLen]		; r12 = aadLen (number of bytes)
-	movdqu	xmm14, [%%GDATA + AadHash]
+        mov     r12, [%%GDATA_C + PBlockLen]		; r12 = aadLen (number of bytes)
+	movdqu	xmm14, [%%GDATA_C + AadHash]
 	movdqu	xmm13, [%%GDATA + HashKey]
 
 	cmp	r12, 0
@@ -1728,12 +1735,12 @@ movdqu  %%T_key, [%%GDATA+16*10]
 	je %%_partial_done
 
 	GHASH_MUL xmm14, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6 ;GHASH computation for the last <16 Byte block
-	movdqu	[%%GDATA+AadHash], xmm14
+	movdqu	[%%GDATA_C + AadHash], xmm14
 
 %%_partial_done:
 
-	mov	r12, [%%GDATA + AadLen]			; r12 = aadLen (number of bytes)
-	mov	%%PLAIN_CYPH_LEN, [%%GDATA + InLen]
+	mov	r12, [%%GDATA_C + AadLen]		; r12 = aadLen (number of bytes)
+	mov	%%PLAIN_CYPH_LEN, [%%GDATA_C + InLen]
 
         shl     r12, 3                                  ; convert into number of bits
         movd    xmm15, r12d                             ; len(A) in xmm15
@@ -1747,7 +1754,7 @@ movdqu  %%T_key, [%%GDATA+16*10]
         GHASH_MUL       xmm14, xmm13, xmm0, xmm10, xmm11, xmm5, xmm6    ; final GHASH computation
         pshufb  xmm14, [SHUF_MASK]              ; perform a 16Byte swap
 
-        movdqu  xmm9, [%%GDATA + OrigIV]                             ; xmm9 = Y0
+        movdqu  xmm9, [%%GDATA_C + OrigIV]                             ; xmm9 = Y0
 
 	ENCRYPT_SINGLE_BLOCK	%%GDATA, xmm9, xmm2	; E(K, Y0)
 
@@ -1845,6 +1852,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_init_sse(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *iv, /* Pre-counter block j0: 4 byte salt (from Security Association) concatenated with 8 byte Initialisation Vector (from IPSec ESP Payload) concatenated with 0x00000001. 16-byte pointer. */
 ;        const   u8 *aad, /* Additional Authentication Data (AAD)*/
 ;        u64     aad_len); /* Length of AAD in bytes (must be a multiple of 4 bytes). */
@@ -1859,7 +1867,7 @@ aesni_gcm128_init_sse:
 	movdqu	[rsp + 0*16],xmm6
 %endif
 
-	GCM_INIT arg1, arg2, arg3, arg4
+	GCM_INIT arg1, arg2, arg3, arg4, arg5
 
 %ifidn __OUTPUT_FORMAT__, win64
 	movdqu	xmm6 , [rsp + 0*16]
@@ -1873,6 +1881,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_enc_update_sse(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Ciphertext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Plaintext input */
 ;        u64     plaintext_len); /* Length of data in Bytes for encryption. must be a multiple of 16 bytes*/
@@ -1882,7 +1891,7 @@ aesni_gcm128_enc_update_sse:
 
 	FUNC_SAVE
 
-	GCM_ENC_DEC arg1, arg2, arg3, arg4, ENC
+	GCM_ENC_DEC arg1, arg2, arg3, arg4, arg5, ENC
 
 	FUNC_RESTORE
 
@@ -1892,6 +1901,7 @@ aesni_gcm128_enc_update_sse:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_dec_update_sse(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Plaintext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Cyphertext input */
 ;        u64     plaintext_len); /* Length of data in Bytes for encryption. must be a multiple of 16 bytes*/
@@ -1901,7 +1911,7 @@ aesni_gcm128_dec_update_sse:
 
 	FUNC_SAVE
 
-	GCM_ENC_DEC arg1, arg2, arg3, arg4, DEC
+	GCM_ENC_DEC arg1, arg2, arg3, arg4, arg5, DEC
 
 	FUNC_RESTORE
 
@@ -1911,6 +1921,7 @@ aesni_gcm128_dec_update_sse:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_enc_finalize_sse(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *auth_tag, /* Authenticated Tag output. */
 ;        u64     auth_tag_len); /* Authenticated Tag Length in bytes. Valid values are 16 (most likely), 12 or 8. */
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1928,7 +1939,7 @@ aesni_gcm128_enc_finalize_sse:
 	movdqu	[rsp + 3*16],xmm14
 	movdqu	[rsp + 4*16],xmm15
 %endif
-	GCM_COMPLETE	arg1, arg2, arg3, ENC
+	GCM_COMPLETE	arg1, arg2, arg3, arg4, ENC
 
 %ifidn __OUTPUT_FORMAT__, win64
 	movdqu	xmm15  , [rsp + 4*16]
@@ -1946,6 +1957,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_dec_finalize_sse(
 ;	 gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *auth_tag, /* Authenticated Tag output. */
 ;        u64     auth_tag_len); /* Authenticated Tag Length in bytes. Valid values are 16 (most likely), 12 or 8. */
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1963,7 +1975,7 @@ aesni_gcm128_dec_finalize_sse:
 	movdqu	[rsp + 3*16],xmm14
 	movdqu	[rsp + 4*16],xmm15
 %endif
-	GCM_COMPLETE	arg1, arg2, arg3, DEC
+	GCM_COMPLETE	arg1, arg2, arg3, arg4, DEC
 
 %ifidn __OUTPUT_FORMAT__, win64
 	movdqu	xmm15  , [rsp + 4*16]
@@ -1981,6 +1993,7 @@ ret
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_enc_sse(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Ciphertext output. Encrypt in-place is allowed.  */
 ;        const   u8 *in, /* Plaintext input */
 ;        u64     plaintext_len, /* Length of data in Bytes for encryption. */
@@ -1995,11 +2008,11 @@ aesni_gcm128_enc_sse:
 
 	FUNC_SAVE
 
-	GCM_INIT arg1, arg5, arg6, arg7
+	GCM_INIT arg1, arg2, arg6, arg7, arg8
 
-	GCM_ENC_DEC  arg1, arg2, arg3, arg4, ENC
+	GCM_ENC_DEC  arg1, arg2, arg3, arg4, arg5, ENC
 
-	GCM_COMPLETE arg1, arg8, arg9, ENC
+	GCM_COMPLETE arg1, arg2, arg9, arg10, ENC
 
 	FUNC_RESTORE
 
@@ -2008,6 +2021,7 @@ aesni_gcm128_enc_sse:
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;void   aesni_gcm128_dec_sse(
 ;        gcm_data        *my_ctx_data,
+;        gcm_data_comp   *my_comp_data,
 ;        u8      *out, /* Plaintext output. Decrypt in-place is allowed.  */
 ;        const   u8 *in, /* Ciphertext input */
 ;        u64     plaintext_len, /* Length of data in Bytes for encryption. */
@@ -2022,11 +2036,11 @@ aesni_gcm128_dec_sse:
 
 	FUNC_SAVE
 
-	GCM_INIT arg1, arg5, arg6, arg7
+	GCM_INIT arg1, arg2, arg6, arg7, arg8
 
-	GCM_ENC_DEC  arg1, arg2, arg3, arg4, DEC
+	GCM_ENC_DEC  arg1, arg2, arg3, arg4, arg5, DEC
 
-	GCM_COMPLETE arg1, arg8, arg9, DEC
+	GCM_COMPLETE arg1, arg2, arg9, arg10, DEC
 
 	FUNC_RESTORE
 


### PR DESCRIPTION
Current design does not support parallel encryption/decryption of the
same gcm_ctx.

Issue can be emulated with one thread with the following test:

// precompute key
aesni_gcm128_pre_xxx(vector->K, &gdata);
// start encryption of a first message
aesni_gcm128_init_xxx(&gdata, ...)
// encrypt first message
aesni_gcm128_enc_update_xxx(&gdata, ...)
// start encryption of a second message
aesni_gcm128_init_xxx(&gdata, ...)
// finalize encryption of the first message
aesni_gcm128_enc_finalize_xxx(&gdata, ...)
// encrypt second message
aesni_gcm128_enc_update_xxx(&gdata, ...)
// finalize encryption of the second message
aesni_gcm128_enc_finalize_xxx(&gdata, ...)

In this case encryption results for both messages are wrong as
information relative to the encryption are in the gdata variable.

To allow encryption with this configuration the gcm_ctx must be split in
two:
 - First part contains only the precomputed key (expanded_keys and
   shifted_hkey_xx)
 - Second part contains information to the ongoing encryption/decryption
   (aad_hash, aad_length, in_length, partial_block_enc_key,
   partial_block_length, orig_IV and current_counter)

The first part is initialized by the aesni_gcm128_pre_xxx function and
use later without any modification.
The second part is initialized by the aesni_gcm128_init_xxx function
and must be provided too the following aesni_gcm128_enc_update_xxx and
aesni_gcm128_enc_finalize_xxx functions.

Way to manage this second part is under the responsability of the caller
of the library.

With this fix the sequence described in the test becomes:

// precompute key
aesni_gcm128_pre_xxx(vector->K, &gdata);
// start encryption of a first message
aesni_gcm128_init_xxx(&gdata, &int_data1, ...)
// encrypt first message
aesni_gcm128_enc_update_xxx(&gdata, &int_data1, ...)
// start encryption of a second message
aesni_gcm128_init_xxx(&gdata, &int_data2, ...)
// finalize encryption of the first message
aesni_gcm128_enc_finalize_xxx(&gdata, &int_data1, ...)
// encrypt second message
aesni_gcm128_enc_update_xxx(&gdata, &int_data2, ...)
// finalize encryption of the second message
aesni_gcm128_enc_finalize_xxx(&gdata, &int_data2, ...)

This change provides correct encryption/decryption results for both
messages.

Performance result with perf tool provides by the latest version of the
intel multibuffer library (https://github.com/01org/intel-ipsec-mb) do
not show any significant differences