### PR TITLE
added arch handlers in mb_mgr

### DIFF
--- a/LibPerfApp/Makefile
+++ b/LibPerfApp/Makefile
@@ -43,6 +43,10 @@ else
 CFLAGS += -O2 -fPIE -fstack-protector -D_FORTIFY_SOURCE=2
 endif
 
+ifeq ($(USE_ARCH_HANDLER),y)
+CFLAGS += -DUSE_ARCH_HANDLER
+endif
+
 SOURCES := ipsec_perf.c
 OBJECTS := $(SOURCES:%.c=%.o)
 

--- a/LibTestApp/gcm_test.c
+++ b/LibTestApp/gcm_test.c
@@ -755,11 +755,6 @@ static gcm_enc_dec_fn_t aesni_gcm256_dec = NULL;
 static gcm_enc_dec_fn_t aesni_gcm256_enc_2 = NULL;
 static gcm_enc_dec_fn_t aesni_gcm256_dec_2 = NULL;
 
-static get_next_job_t get_next_job = NULL;
-static submit_job_t submit_job = NULL;
-static get_completed_job_t get_completed_job = NULL;
-static flush_job_t flush_job = NULL;
-
 static MB_MGR gcm_mgr;
 
 static int check_data(const uint8_t *test, const uint8_t * expected, uint64_t len,
@@ -1020,7 +1015,7 @@ aes_gcm_job(MB_MGR *mb_mgr,
 {
         JOB_AES_HMAC *job;
 
-        job = get_next_job(mb_mgr);
+        job = MB_GET_NEXT_JOB(mb_mgr);
         if (!job) {
                 fprintf(stderr, "failed to get job\n");
                 return;
@@ -1045,13 +1040,13 @@ aes_gcm_job(MB_MGR *mb_mgr,
         job->cipher_direction                 =
                 (order == CIPHER_HASH) ? ENCRYPT : DECRYPT;
                 
-        job = submit_job(mb_mgr);
+        job = MB_SUBMIT_JOB(mb_mgr);
         while (job) {
                 if (job->status != STS_COMPLETED)
                         fprintf(stderr, "failed job, status:%d\n", job->status);
-                job = get_completed_job(mb_mgr);
+                job = MB_GET_COMPLETED_JOB(mb_mgr);
         }
-        while ((job = flush_job(mb_mgr)) != NULL) {
+        while ((job = MB_FLUSH_JOB(mb_mgr)) != NULL) {
                 if (job->status != STS_COMPLETED)
                         fprintf(stderr, "failed job, status:%d\n", job->status);
         }
@@ -1317,10 +1312,6 @@ int gcm_test(const enum arch_type arch)
                 aesni_gcm256_enc_2 = sgl_aes_gcm_enc_256_sse;
                 aesni_gcm256_dec_2 = sgl_aes_gcm_dec_256_sse;
                 init_mb_mgr_sse(&gcm_mgr);
-                get_next_job      = get_next_job_sse;
-                submit_job        = submit_job_sse;
-                get_completed_job = get_completed_job_sse;
-                flush_job         = flush_job_sse;
                 break;
         case ARCH_AVX:
                 aesni_gcm128_pre = aes_gcm_pre_128_avx_gen2;
@@ -1339,10 +1330,6 @@ int gcm_test(const enum arch_type arch)
                 aesni_gcm256_enc_2 = sgl_aes_gcm_enc_256_avx_gen2;
                 aesni_gcm256_dec_2 = sgl_aes_gcm_dec_256_avx_gen2;
                 init_mb_mgr_avx(&gcm_mgr);
-                get_next_job      = get_next_job_avx;
-                submit_job        = submit_job_avx;
-                get_completed_job = get_completed_job_avx;
-                flush_job         = flush_job_avx;
                 break;
         case ARCH_AVX2:
                 aesni_gcm128_pre = aes_gcm_pre_128_avx_gen4;
@@ -1361,10 +1348,6 @@ int gcm_test(const enum arch_type arch)
                 aesni_gcm256_enc_2 = sgl_aes_gcm_enc_256_avx_gen4;
                 aesni_gcm256_dec_2 = sgl_aes_gcm_dec_256_avx_gen4;
                 init_mb_mgr_avx2(&gcm_mgr);
-                get_next_job      = get_next_job_avx2;
-                submit_job        = submit_job_avx2;
-                get_completed_job = get_completed_job_avx2;
-                flush_job         = flush_job_avx2;
                 break;
         case ARCH_AVX512:
                 aesni_gcm128_pre = aes_gcm_pre_128_avx_gen4;
@@ -1383,10 +1366,6 @@ int gcm_test(const enum arch_type arch)
                 aesni_gcm256_enc_2 = sgl_aes_gcm_enc_256_avx_gen4;
                 aesni_gcm256_dec_2 = sgl_aes_gcm_dec_256_avx_gen4;
                 init_mb_mgr_avx512(&gcm_mgr);
-                get_next_job      = get_next_job_avx512;
-                submit_job        = submit_job_avx512;
-                get_completed_job = get_completed_job_avx512;
-                flush_job         = flush_job_avx512;
                 break;
         default:
                 printf("Invalid architecture type %d selected!\n", arch);

--- a/avx/mb_mgr_avx.c
+++ b/avx/mb_mgr_avx.c
@@ -426,6 +426,14 @@ init_mb_mgr_avx(MB_MGR *state)
         // Init "in order" components
         state->next_job = 0;
         state->earliest_job = -1;
+
+        /* set handlers */
+        state->get_next           = get_next_job_avx;
+        state->submit_job         = submit_job_avx;
+        state->submit_job_nocheck = submit_job_nocheck_avx;
+        state->get_completed_job  = get_completed_job_avx;
+        state->flush_job          = flush_job_avx;
+        state->queue_size         = queue_size_avx;
 }
 
 

--- a/avx2/mb_mgr_avx2.c
+++ b/avx2/mb_mgr_avx2.c
@@ -430,6 +430,14 @@ init_mb_mgr_avx2(MB_MGR *state)
         // Init "in order" components
         state->next_job = 0;
         state->earliest_job = -1;
+
+        /* set handlers */
+        state->get_next           = get_next_job_avx2;
+        state->submit_job         = submit_job_avx2;
+        state->submit_job_nocheck = submit_job_nocheck_avx2;
+        state->get_completed_job  = get_completed_job_avx2;
+        state->flush_job          = flush_job_avx2;
+        state->queue_size         = queue_size_avx2;
 }
 
 

--- a/avx512/mb_mgr_avx512.c
+++ b/avx512/mb_mgr_avx512.c
@@ -451,6 +451,14 @@ init_mb_mgr_avx512(MB_MGR *state)
         // Init "in order" components
         state->next_job = 0;
         state->earliest_job = -1;
+
+        /* set handlers */
+        state->get_next           = get_next_job_avx512;
+        state->submit_job         = submit_job_avx512;
+        state->submit_job_nocheck = submit_job_nocheck_avx512;
+        state->get_completed_job  = get_completed_job_avx512;
+        state->flush_job          = flush_job_avx512;
+        state->queue_size         = queue_size_avx512;
 }
 
 

--- a/sse/mb_mgr_sse.c
+++ b/sse/mb_mgr_sse.c
@@ -568,6 +568,14 @@ init_mb_mgr_sse(MB_MGR *state)
         // Init "in order" components
         state->next_job = 0;
         state->earliest_job = -1;
+
+        /* set handlers */
+        state->get_next           = get_next_job_sse;
+        state->submit_job         = submit_job_sse;
+        state->submit_job_nocheck = submit_job_nocheck_sse;
+        state->get_completed_job  = get_completed_job_sse;
+        state->flush_job          = flush_job_sse;
+        state->queue_size         = queue_size_sse;
 }
 
 #include "mb_mgr_code.h"


### PR DESCRIPTION
        I added an API handler for every arch (sse, avx, avx2, avx 512) to
        mb_mgr. These can be used with the following macros.
                MB_GET_NEXT_JOB ()
                MB_SUBMIT_JOB ()
                MB_SUBMIT_JOB_NOCHECK ()
                MB_GET_COMPLETED_JOB ()
                MB_FLUSH_JOB ()
                MB_QUEUE_SIZE ()