### PR TITLE
added addon-(cipher,hash) algorithm

### DIFF
--- a/LibTestApp/Makefile
+++ b/LibTestApp/Makefile
@@ -24,8 +24,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
+
 MYLIB = ../libIPSec_MB.a
 CFLAGS = -g -DLINUX -I../include -I..
+
 ifeq ($(DEBUG),y)
 CFLAGS += -O0 -DDEBUG
 else
@@ -36,13 +39,14 @@ APP := ipsec_MB_testapp
 
 all: $(APP)
 
-$(APP): main.o gcm_test.o ctr_test.o $(MYLIB)
-	$(CC) $(LDFLAGS) -o $@ $^
+$(APP): main.o gcm_test.o ctr_test.o addon_test.o $(MYLIB)
+	$(CC) $(LDFLAGS) -o $@ $^ $(MYLIB)
 
 main.o: main.c do_test.h
 gcm_test.o: gcm_test.c gcm_ctr_vectors_test.h
 ctr_test.o: ctr_test.c gcm_ctr_vectors_test.h
+addon_test.o: addon_test.c addon_test.h
 
 .PHONY: clean
 clean:
-	-rm -f main.o gcm_test.o ctr_test.o $(APP)
+	-rm -f main.o gcm_test.o ctr_test.o addon_test.o $(APP)

--- a/LibTestApp/addon_test.c
+++ b/LibTestApp/addon_test.c
@@ -1,0 +1,369 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Intel Corporation nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sys/queue.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <mb_mgr.h>
+
+#include "addon_test.h"
+
+
+#if defined(DEBUG)
+# define TRACE(fmt, ...)	fprintf(stderr, "%s:%d "fmt, __func__, __LINE__, __VA_ARGS__)
+#else
+# define TRACE(fmt, ...)
+#endif
+
+struct cipher_attr_s {
+        const char *name;
+        JOB_CIPHER_MODE mode;
+        unsigned key_len;
+        unsigned iv_len;
+};
+
+struct auth_attr_s {
+        const char *name;
+        JOB_HASH_ALG hash;
+        unsigned tag_len;
+};
+
+struct test_vec_s {
+        uint8_t iv[16];
+        uint8_t txt[64];
+        uint8_t tag[32];
+        uint8_t verify[32];
+                
+        uint8_t enc_key[16*16];
+        uint8_t dec_key[16*16];
+        uint8_t ipad[256];
+        uint8_t opad[256];
+        const struct cipher_attr_s *cipher;
+        const struct auth_attr_s *auth;
+        
+        STAILQ_ENTRY(test_vec_s) entry;
+        unsigned seq;
+};
+
+/*
+ * addon cipher function
+ */
+static int
+cipher_addon(struct JOB_AES_HMAC *job)
+{
+        struct test_vec_s *node = job->user_data;
+        int ret;
+        
+        TRACE("Seq:%u Cipher Addon cipher:%s auth:%s\n",
+              node->seq, node->cipher->name, node->auth->name);
+
+        if (job->cipher_direction == ENCRYPT) {
+                memset(job->dst, 1, job->msg_len_to_cipher_in_bytes);
+        } else {
+                memset(job->dst, 2, job->msg_len_to_cipher_in_bytes);
+        }
+        return 0;	/* success */
+}
+
+/*
+ * addon hash function
+ */
+static int
+hash_addon(struct JOB_AES_HMAC *job)
+{
+        struct test_vec_s *node = job->user_data;
+        
+        TRACE("Seq:%u Auth Addon cipher:%s auth:%s\n",
+              node->seq, node->cipher->name, node->auth->name);
+
+        memset(job->auth_tag_output, 3, job->auth_tag_output_len_in_bytes);
+        return 0;	/* success */
+}
+
+/*
+ * test cipher functions
+ */
+static const struct auth_attr_s AUTH_ATTR[] = {
+        {
+                .name = "SHA1",
+                .hash = SHA1,
+                .tag_len = 12,
+        },
+        {
+                .name = "SHA224",
+                .hash = SHA_224,
+                .tag_len = 14,
+        },
+        {
+                .name = "SHA256",
+                .hash = SHA_256,
+                .tag_len = 16,
+        },
+        {
+                .name = "SHA384",
+                .hash = SHA_384,
+                .tag_len = 24,
+        },
+        {
+                .name = "SHA512",
+                .hash = SHA_512,
+                .tag_len = 32,
+        },
+        {
+                .name = "MD5",
+                .hash = MD5,
+                .tag_len = 12,
+        },
+        {
+                .name = "HASH_ADDON",
+                .hash = HASH_ADDON,
+                .tag_len = 16,
+        },
+};
+
+/*
+ * test hash functions
+ */
+static const struct cipher_attr_s  CIPHER_ATTR[] = {
+        {
+                .name = "CBC128",
+                .mode = CBC,
+                .key_len = 16,
+                .iv_len = 16,
+        },
+        {
+                .name = "CBC192",
+                .mode = CBC,
+                .key_len = 24,
+                .iv_len = 16,
+        },
+        {
+                .name = "CBC256",
+                .mode = CBC,
+                .key_len = 32,
+                .iv_len = 16,
+        },
+        
+        {
+                .name = "CIPHER_ADDON",
+                .mode = CIPHER_ADDON,
+                .key_len = 32,
+                .iv_len = 12,
+        },
+
+        {
+                .name = "CTR128",
+                .mode = CNTR,
+                .key_len = 16,
+                .iv_len = 8,
+        },
+        {
+                .name = "CTR192",
+                .mode = CNTR,
+                .key_len = 24,
+                .iv_len = 8,
+        },
+        {
+                .name = "CTR256",
+                .mode = CNTR,
+                .key_len = 32,
+                .iv_len = 8,
+        },
+};
+
+#define ARRAYOF(_a)	(sizeof(_a) / sizeof(_a[0]))
+
+static inline int
+job_check(const struct JOB_AES_HMAC *job)
+{
+        struct test_vec_s *done = job->user_data;
+
+        TRACE("done Seq:%u Cipher:%s Auth:%s\n",
+              done->seq, done->cipher->name, done->auth->name);
+
+        if (job->status != STS_COMPLETED) {
+                TRACE("failed job status:%d\n", job->status);
+                return -1;
+        }
+        if (job->cipher_mode == CIPHER_ADDON) {
+                if (job->cipher_direction == ENCRYPT) {
+                        for (unsigned i = 0; i < job->msg_len_to_cipher_in_bytes; i++) {
+                                if (job->dst[i] != 1) {
+                                        TRACE("NG add-on encryption %u\n", i);
+                                        return -1;
+                                }
+                        }
+                        TRACE("Addon encryption passes Seq:%u\n", done->seq);
+                } else {
+                        for (unsigned i = 0; i < job->msg_len_to_cipher_in_bytes; i++) {
+                                if (job->dst[i] != 2) {
+                                        TRACE("NG add-on decryption %u\n", i);
+                                        return -1;
+                                }
+                        }
+                        TRACE("Addon decryption passes Seq:%u\n", done->seq);
+                }
+        }
+
+        if (job->hash_alg == HASH_ADDON) {
+                for (unsigned i = 0; i < job->auth_tag_output_len_in_bytes; i++) {
+                        if (job->auth_tag_output[i] != 3) {
+                                TRACE("NG add-on hashing %u\n", i);
+                                return -1;
+                        }
+                }
+                TRACE("Addon hashing passes Seq:%u\n", done->seq);
+        }
+        return 0;
+}
+
+
+void
+addon_test(struct MB_MGR *mgr)
+{
+        STAILQ_HEAD(test_vec_head, test_vec_s) head = STAILQ_HEAD_INITIALIZER(head);
+        struct test_vec_s *node, *done;
+        struct JOB_AES_HMAC *job;
+        unsigned seq = 0;
+        int result = 0;
+
+        /* encryption */
+        for (unsigned i = 0; i < ARRAYOF(CIPHER_ATTR); i++) {
+                for (unsigned j = 0; j < ARRAYOF(AUTH_ATTR); j++) {
+                        while ((job = IMB_GET_NEXT_JOB(mgr)) == NULL) {
+                                job = IMB_FLUSH_JOB(mgr);
+                                result |= job_check(job);
+                                done = job->user_data;
+                                STAILQ_INSERT_TAIL(&head, done, entry);
+                        }
+                        node = malloc(sizeof(*node));
+                        node->seq = seq++;
+
+                        node->cipher = &CIPHER_ATTR[i];
+                        node->auth = &AUTH_ATTR[j];
+
+
+                        job->cipher_func = cipher_addon;
+                        job->hash_func = hash_addon;
+
+                        job->aes_enc_key_expanded = node->enc_key;
+                        job->aes_dec_key_expanded = node->dec_key;
+                        job->aes_key_len_in_bytes = node->cipher->key_len;
+                        job->src = node->txt;
+                        job->dst = node->txt;
+                        job->cipher_start_src_offset_in_bytes = 16;
+                        job->msg_len_to_cipher_in_bytes = sizeof(node->txt);
+                        job->hash_start_src_offset_in_bytes = 0;
+                        job->msg_len_to_hash_in_bytes = sizeof(node->txt) + sizeof(node->iv);
+                        job->iv = node->iv;
+                        job->iv_len_in_bytes = node->cipher->iv_len;
+                        job->auth_tag_output = node->tag;
+                        job->auth_tag_output_len_in_bytes = node->auth->tag_len;
+                                
+                        job->u.HMAC._hashed_auth_key_xor_ipad = node->ipad;
+                        job->u.HMAC._hashed_auth_key_xor_opad = node->opad;
+                        job->cipher_mode = node->cipher->mode;
+                        job->cipher_direction = ENCRYPT;
+                        job->chain_order = CIPHER_HASH;
+                        job->hash_alg = node->auth->hash;
+                        job->user_data = node;
+
+                        job = IMB_SUBMIT_JOB_NOCHECK(mgr);
+                        while (job) {
+                                result |= job_check(job);
+                                done = job->user_data;
+                                STAILQ_INSERT_TAIL(&head, done, entry);
+                                
+                                job = IMB_GET_COMPLETED_JOB(mgr);
+                        }
+                }
+        }
+        while ((job = IMB_FLUSH_JOB(mgr)) != NULL) {
+                result |= job_check(job);
+                done = job->user_data;
+                STAILQ_INSERT_TAIL(&head, done, entry);
+        }
+
+        /* decryption */
+        while ((node = STAILQ_FIRST(&head)) != NULL) {
+                STAILQ_REMOVE_HEAD(&head, entry);
+                
+                while ((job = IMB_GET_NEXT_JOB(mgr)) == NULL) {
+                        job = IMB_FLUSH_JOB(mgr);
+                        result |= job_check(job);
+                        done = job->user_data;
+                        free(done);
+                }
+
+                job->cipher_func = cipher_addon;
+                job->hash_func = hash_addon;
+
+                job->aes_enc_key_expanded = node->enc_key;
+                job->aes_dec_key_expanded = node->dec_key;
+                job->aes_key_len_in_bytes = node->cipher->key_len;
+                job->src = node->txt;
+                job->dst = node->txt;
+                job->cipher_start_src_offset_in_bytes = 16;
+                job->msg_len_to_cipher_in_bytes = sizeof(node->txt);
+                job->hash_start_src_offset_in_bytes = 0;
+                job->msg_len_to_hash_in_bytes = sizeof(node->txt) + sizeof(node->iv);
+                job->iv = node->iv;
+                job->iv_len_in_bytes = node->cipher->iv_len;
+                job->auth_tag_output = node->tag;
+                job->auth_tag_output_len_in_bytes = node->auth->tag_len;
+                                
+                job->u.HMAC._hashed_auth_key_xor_ipad = node->ipad;
+                job->u.HMAC._hashed_auth_key_xor_opad = node->opad;
+                job->cipher_mode = node->cipher->mode;
+                job->cipher_direction = DECRYPT;
+                job->chain_order = HASH_CIPHER;
+                job->hash_alg = node->auth->hash;
+                job->user_data = node;
+
+                job = IMB_SUBMIT_JOB_NOCHECK(mgr);
+                while (job) {
+                        result |= job_check(job);
+                        done = job->user_data;
+                        free(done);
+                                
+                        job = IMB_GET_COMPLETED_JOB(mgr);
+                }
+        }
+
+        while ((job = IMB_FLUSH_JOB(mgr)) != NULL) {
+                result |= job_check(job);
+                done = job->user_data;
+                free(done);
+         }
+
+        if (result)
+                fprintf(stdout, "failed addon test\n");
+        else
+                fprintf(stdout, "Addon test passes\n");
+}

--- a/LibTestApp/addon_test.h
+++ b/LibTestApp/addon_test.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of Intel Corporation nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _ADDON_TEST_H_
+#define _ADDON_TEST_H_
+
+#ifndef NO_ADDON
+
+struct MB_MGR;
+extern void addon_test(struct MB_MGR *state);
+
+
+#endif /* !NO_ADDON */
+
+#endif /* !_ADDON_TEST_H_ */

--- a/LibTestApp/do_test.h
+++ b/LibTestApp/do_test.h
@@ -31,10 +31,6 @@
 #include <stdint.h>
 
 #undef init_mb_mgr
-#undef get_next_job
-#undef submit_job
-#undef flush_job
-#undef get_completed_job
 
 #undef sha1_one_block
 #undef sha224_one_block
@@ -54,10 +50,6 @@
 
 #if (TEST == TEST_AVX)
 #define init_mb_mgr       init_mb_mgr_avx
-#define get_next_job      get_next_job_avx
-#define submit_job        submit_job_avx
-#define flush_job         flush_job_avx
-#define get_completed_job get_completed_job_avx
 
 #define sha1_one_block      sha1_one_block_avx
 #define sha224_one_block    sha224_one_block_avx
@@ -76,10 +68,6 @@
 #define TEST_AUX_FUNC     test_aux_func_avx
 #elif (TEST == TEST_AVX2)
 #define init_mb_mgr       init_mb_mgr_avx2
-#define get_next_job      get_next_job_avx2
-#define submit_job        submit_job_avx2
-#define flush_job         flush_job_avx2
-#define get_completed_job get_completed_job_avx2
 
 #define sha1_one_block      sha1_one_block_avx2
 #define sha224_one_block    sha224_one_block_avx2
@@ -98,10 +86,6 @@
 #define TEST_AUX_FUNC     test_aux_func_avx2
 #elif (TEST == TEST_AVX512)
 #define init_mb_mgr       init_mb_mgr_avx512
-#define get_next_job      get_next_job_avx512
-#define submit_job        submit_job_avx512
-#define flush_job         flush_job_avx512
-#define get_completed_job get_completed_job_avx512
 
 #define sha1_one_block      sha1_one_block_avx512
 #define sha224_one_block    sha224_one_block_avx512
@@ -120,10 +104,6 @@
 #define TEST_AUX_FUNC     test_aux_func_avx512
 #else
 #define init_mb_mgr       init_mb_mgr_sse
-#define get_next_job      get_next_job_sse
-#define submit_job        submit_job_sse
-#define flush_job         flush_job_sse
-#define get_completed_job get_completed_job_sse
 
 #define sha1_one_block      sha1_one_block_sse
 #define sha224_one_block    sha224_one_block_sse
@@ -241,11 +221,11 @@ KNOWN_ANSWER_TEST(MB_MGR *mb_mgr)
 
 
         // Expand key
-        aes_keyexp_128(key128, enc_keys, dec_keys);
+        IMB_AES_KEYEXP_128(mb_mgr, key128, enc_keys, dec_keys);
 
 
         // test AES128 Dec
-        job = get_next_job(mb_mgr);
+        job = IMB_GET_NEXT_JOB(mb_mgr);
 
         job->aes_enc_key_expanded = enc_keys;
         job->aes_dec_key_expanded = dec_keys;
@@ -268,12 +248,12 @@ KNOWN_ANSWER_TEST(MB_MGR *mb_mgr)
         job->cipher_mode = CBC;
         job->hash_alg = SHA1;
 
-        job = submit_job(mb_mgr);
+        job = IMB_SUBMIT_JOB(mb_mgr);
         if (job) {
                 printf("Unexpected return from submit_job\n");
                 return;
         }
-        job = flush_job(mb_mgr);
+        job = IMB_FLUSH_JOB(mb_mgr);
         if (!job) {
                 printf("Unexpected null return from flush_job\n");
                 return;
@@ -332,7 +312,7 @@ DO_TEST(MB_MGR *mb_mgr)
         static uint8_t buf[4096+20];
 
         for (size = 32; size < 4096; size += 16) {
-                job = get_next_job(mb_mgr);
+                job = IMB_GET_NEXT_JOB(mb_mgr);
 
                 job->msg_len_to_cipher_in_bytes = size;
                 job->msg_len_to_hash_in_bytes = size + 20;
@@ -366,13 +346,13 @@ DO_TEST(MB_MGR *mb_mgr)
                         job->cipher_direction = DECRYPT;
                         job->chain_order = HASH_CIPHER;
                 }
-                job = submit_job(mb_mgr);
+                job = IMB_SUBMIT_JOB(mb_mgr);
                 while (job) {
-                        job = get_completed_job(mb_mgr);
+                        job = IMB_GET_COMPLETED_JOB(mb_mgr);
                 } // end while (job)
         } // end for i
 
-        while ((job = flush_job(mb_mgr)) != NULL) {
+        while ((job = IMB_FLUSH_JOB(mb_mgr)) != NULL) {
         }
 
         TEST_AUX_FUNC();

--- a/LibTestApp/main.c
+++ b/LibTestApp/main.c
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2012-2017, Intel Corporation
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright notice,
  *       this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -12,7 +12,7 @@
  *     * Neither the name of Intel Corporation nor the names of its contributors
  *       may be used to endorse or promote products derived from this software
  *       without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -29,9 +29,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "mb_mgr.h"
-#include "aux_funcs.h"
+#include <mb_mgr.h>
+#include <aux_funcs.h>
+
 #include "gcm_ctr_vectors_test.h"
+#include "addon_test.h"
 
 #define TEST_SSE  1
 #define TEST_AVX  2
@@ -97,6 +99,9 @@ main(int argc, char **argv)
                 do_test_sse(&mb_mgr);
                 ctr_test(ARCH_SSE, &mb_mgr);
                 gcm_test(ARCH_SSE);
+#ifndef NO_ADDON
+                addon_test(&mb_mgr);
+#endif /* !NO_ADDON */
         }
 
         if (do_avx) {
@@ -106,6 +111,9 @@ main(int argc, char **argv)
                 do_test_avx(&mb_mgr);
                 ctr_test(ARCH_AVX, &mb_mgr);
                 gcm_test(ARCH_AVX);
+#ifndef NO_ADDON
+                addon_test(&mb_mgr);
+#endif /* !NO_ADDON */
         }
 
         if (do_avx2) {
@@ -115,6 +123,9 @@ main(int argc, char **argv)
                 do_test_avx2(&mb_mgr);
                 ctr_test(ARCH_AVX2, &mb_mgr);
                 gcm_test(ARCH_AVX2);
+#ifndef NO_ADDON
+                addon_test(&mb_mgr);
+#endif /* !NO_ADDON */
         }
 
         if (do_avx512) {
@@ -124,6 +135,9 @@ main(int argc, char **argv)
                 do_test_avx512(&mb_mgr);
                 ctr_test(ARCH_AVX512, &mb_mgr);
                 gcm_test(ARCH_AVX512);
+#ifndef NO_ADDON
+                addon_test(&mb_mgr);
+#endif /* !NO_ADDON */
         }
 
         printf("Test completed\n");

--- a/job_aes_hmac.h
+++ b/job_aes_hmac.h
@@ -43,8 +43,11 @@ typedef enum {
         NULL_CIPHER,
         DOCSIS_SEC_BPI,
 #ifndef NO_GCM
-        GCM
+        GCM,
 #endif /* !NO_GCM */
+#ifndef NO_ADDON
+        CIPHER_ADDON,
+#endif /* !NO_ADDON */
 } JOB_CIPHER_MODE;
 
 typedef enum {
@@ -62,8 +65,11 @@ typedef enum {
         MD5,
         NULL_HASH,
 #ifndef NO_GCM
-        AES_GMAC
+        AES_GMAC,
 #endif /* !NO_GCM */
+#ifndef NO_ADDON
+        HASH_ADDON,
+#endif /* !NO_ADDON */
 } JOB_HASH_ALG;
 
 typedef enum {
@@ -120,8 +126,20 @@ typedef struct JOB_AES_HMAC {
         // by the chain _order field.
         JOB_HASH_ALG hash_alg; // SHA-1 or others...
         JOB_CHAIN_ORDER chain_order; // CIPHER_HASH or HASH_CIPHER
+        int _reserved;
         void    *user_data;
         void    *user_data2;
+
+#ifndef NO_ADDON
+        /*
+         * state less cipher and hash add-on
+         *   Return:
+         *     success: 0
+         *     fail:    other
+         */
+        int (*cipher_func)(struct JOB_AES_HMAC *);
+        int (*hash_func)(struct JOB_AES_HMAC *);
+#endif /* !NO_ADDON */
 } JOB_AES_HMAC;
 
 #define hashed_auth_key_xor_ipad u.HMAC._hashed_auth_key_xor_ipad

--- a/mb_mgr.h
+++ b/mb_mgr.h
@@ -50,7 +50,7 @@ typedef struct {
 typedef struct {
         DECLARE_ALIGNED(UINT8 final_block[2*16], 32);
         JOB_AES_HMAC *job_in_lane;
-        UINT64 final_done; 
+        UINT64 final_done;
 } XCBC_LANE_DATA;
 
 typedef struct {
@@ -67,7 +67,7 @@ typedef struct {
 
 // used for SHA1 and SHA256
 typedef struct {
-        DECLARE_ALIGNED(UINT8 extra_block[2 * SHA1_BLOCK_SIZE+8], 32); // allows ymm aligned access 
+        DECLARE_ALIGNED(UINT8 extra_block[2 * SHA1_BLOCK_SIZE+8], 32); // allows ymm aligned access
         JOB_AES_HMAC *job_in_lane;
         UINT8 outer_block[64];
         UINT32 outer_done;


### PR DESCRIPTION
Supports addition of optional CIPHER and HASH algorithms in NOCHECK mode.
As a result, 3DES, CHACHA 20-POLY 1305, etc. can also be used with MB API.

The addon function should return zero on success and return otherwise.

The test code is rough, is it OK?